### PR TITLE
Small fix to readme for proper npm run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To start all of the supporting services (Mongo, etc.):
 `docker-compose up -d`
 
 To start the Express web server and run the application at [http://localhost:3000](http://localhost:3000):
-`npm dev-start`
+`npm run dev-start`
 
 This is in development mode and code changes will immediately be loaded without having to restart the server.
 


### PR DESCRIPTION
## Why was this change made?

I get an error when running `npm dev-start`, I'm required to run `npm run dev-start`

## How was this change tested?

N/A


## Which documentation and/or configurations were updated?

README


