### PR TITLE
Allow timestamp to be provided to support migration.

### DIFF
--- a/src/endpoints/resources.js
+++ b/src/endpoints/resources.js
@@ -136,7 +136,10 @@ const resourceForSave = (resource, id, uri) => {
   // If resource has a uri, keep it. This is to support migrations.
   if(!newResource.uri) newResource.uri = uri
   // For querying, need to use a JS date
-  newResource.timestamp = new Date()
+  // Use provided timestamp or create a new one.
+  // Allowing a provided timestamp can be removed once migration is completed.
+  const timestamp = newResource.timestamp ? new Date(newResource.timestamp) : new Date()
+  newResource.timestamp = timestamp
   return newResource
 }
 


### PR DESCRIPTION
## Why was this change made?
To allow a timestamp to be provided as part of migration.


## How was this change tested?
Locally.


## Which documentation and/or configurations were updated?
NA



