### PR TITLE
Don't require URI to have label.

### DIFF
--- a/setup/rt_uri_doc.json
+++ b/setup/rt_uri_doc.json
@@ -57,11 +57,6 @@
           "@id": "http://www.w3.org/2000/01/rdf-schema#label"
         }
       ],
-      "http://sinopia!io/vocabulary/hasPropertyAttribute": [
-        {
-          "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
-        }
-      ],
       "http://sinopia!io/vocabulary/hasPropertyType": [
         {
           "@id": "http://sinopia.io/vocabulary/propertyType/literal"


### PR DESCRIPTION
## Why was this change made?
So that a label is not required for defaults for URIs.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
NA


