### PR TITLE
Switch template id to literal.

### DIFF
--- a/setup/rt_resource_template_doc.json
+++ b/setup/rt_resource_template_doc.json
@@ -135,7 +135,7 @@
       ],
       "http://sinopia!io/vocabulary/hasPropertyType": [
         {
-          "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+          "@id": "http://sinopia.io/vocabulary/propertyType/literal"
         }
       ]
     },


### PR DESCRIPTION
## Why was this change made?
Template id is being switched from a URI to a literal.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
NA



