### PR TITLE
Adds querying by timestamp and type. Fixes date handling.

### DIFF
--- a/__tests__/endpoints/resourcePost.test.js
+++ b/__tests__/endpoints/resourcePost.test.js
@@ -53,12 +53,12 @@ describe('POST /resource/:resourceId', () => {
     expect(res.header.location).toEqual('https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041')
     const saveResource = {...resource}
     delete saveResource._id
-    saveResource.timestamp = new Date().toISOString()
+    saveResource.timestamp = new Date()
     expect(mockResourcesInsert).toHaveBeenCalledWith(saveResource)
     expect(mockResourceVersionsInsert).toHaveBeenCalledWith(saveResource)
 
     const expectedResourceMetadata = {...resourceMetadata}
-    expectedResourceMetadata.versions[0].timestamp = new Date().toISOString()
+    expectedResourceMetadata.versions[0].timestamp = new Date()
     expect(mockResourceMetadataInsert).toHaveBeenCalledWith(expectedResourceMetadata)
   })
   it('requires auth', async () => {

--- a/__tests__/endpoints/resourcePut.test.js
+++ b/__tests__/endpoints/resourcePut.test.js
@@ -51,12 +51,12 @@ describe('PUT /resource/:resourceId', () => {
     expect(res.body).toEqual(resBody)
     const saveResource = {...resource}
     delete saveResource._id
-    saveResource.timestamp = new Date().toISOString()
+    saveResource.timestamp = new Date()
     expect(mockResourcesUpdate).toHaveBeenCalledWith({id: '6852a770-2961-4836-a833-0b21a9b68041'}, saveResource, {replaceOne: true})
     expect(mockResourceVersionsInsert).toHaveBeenCalledWith(saveResource)
 
     const versionEntry = {
-      "timestamp": new Date().toISOString(),
+      "timestamp": new Date(),
       "user": "havram",
       "group": "stanford",
       "templateId": "profile:bf2:Title:AbbrTitle"

--- a/src/error.js
+++ b/src/error.js
@@ -11,6 +11,9 @@ export const handleError = (req, res) => {
       // S3
       errors.push({title: 'Not found', details: err.toString(), code: '404'})
       statusCode = 404
+    } else if (err.code === 'BadRequest') {
+      errors.push({title: 'Bad Request', details: err.toString(), code: '400'})
+      statusCode = 400
     } else {
       errors.push({title: 'Server error', details: err.toString(), code: '500'})
     }


### PR DESCRIPTION
closes #52

## Why was this change made?
* To allow SHARE VDE to query resources by type and timestamp.
* To fix handling of dates. (For Mongo to support querying, they must be JS Dates, not strings.)

## How was this change tested?
Unit, locally.


## Which documentation and/or configurations were updated?
API now matches openapi spec.



