### PR TITLE
Add coverage report to npm test and add test-verbose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # NPM deps
 node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "node src/server.js",
     "eslint": "eslint --color -c .eslintrc.yml --ext js .",
     "eslint-fix": "eslint --color -c .eslintrc.yml --ext js --fix .",
-    "test": "jest --colors --runInBand",
+    "test": "jest --colors --coverage --silent --runInBand",
+    "test-verbose": "jest --colors --runInBand",
     "ci": "npm run eslint && npm run test"
   },
   "type": "module",


### PR DESCRIPTION
## Why was this change made?

Updates the npm test command to include coverage and moves the existing test into test-verbose to match our other repository command patterns.

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A


