### PR TITLE
Add additional error.js coverage

### DIFF
--- a/__tests__/endpoints/resourcePut.test.js
+++ b/__tests__/endpoints/resourcePut.test.js
@@ -70,11 +70,20 @@ describe('PUT /resource/:resourceId', () => {
     expect(res.statusCode).toEqual(401)
   })
   it('returns 404 when resource does not exist', async () => {
-    mockResourcesUpdate.mockResolvedValue({nModified: 0})
+    const err = new Error('Resource Not Found')
+    err.code = 'NoSuchKey'
+    mockResourcesUpdate.mockRejectedValue(err)
     const res = await request(app)
       .put('/resource/6852a770-2961-4836-a833-0b21a9b68041')
       .set('Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.fLGW-NqeXUex3gZpZW0e61zP5dmhmjNPCdBikj_7Djg')
       .send(reqBody)
     expect(res.statusCode).toEqual(404)
+    expect(res.body).toEqual([
+      {
+        title: 'Not found',
+        details: 'Error: Resource Not Found',
+        code: '404'
+      }
+    ])
   })
 })


### PR DESCRIPTION
## Why was this change made?

Part of #4 

Adds a small test to increase coverage of `error.js`

## How was this change tested?

Unit test

## Which documentation and/or configurations were updated?

N/A



