### PR TITLE
Add test coverage for mongo.js

### DIFF
--- a/__tests__/docdb.test.js
+++ b/__tests__/docdb.test.js
@@ -1,0 +1,20 @@
+/* eslint multiline-comment-style: ["error", "starred-block"] */
+/*
+ * Note: This test and mongodb.test.js are nearly identical,
+ * however the 2 main differences do not properly reset (ENV)
+ * when run in the same test suite. Seperating them is required.
+ */
+import fs from 'fs'
+import monk from 'monk'
+
+jest.mock('monk')
+
+describe('connect to aws docdb', () => {
+  it('returns an aws client', () => {
+    process.env.MONGODB_IS_AWS = 'true'
+    const connect = require('mongo.js').default // eslint-disable-line global-require
+    const ca = [fs.readFileSync('rds-combined-ca-bundle.pem')]
+    connect()
+    expect(monk).toHaveBeenCalledWith("mongodb://sinopia:sekret@localhost:27017/sinopia_repository?ssl=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false", { sslValidate: true, sslCA: ca, useNewUrlParser: true })
+  })
+})

--- a/__tests__/mongodb.test.js
+++ b/__tests__/mongodb.test.js
@@ -1,0 +1,18 @@
+/* eslint multiline-comment-style: ["error", "starred-block"] */
+/*
+ * Note: This test and docdb.test.js are nearly identical,
+ * however the 2 main differences do not properly reset (ENV)
+ * when run in the same test suite. Seperating them is required.
+ */
+import monk from 'monk'
+
+jest.mock('monk')
+
+describe('connect to mongodb', () => {
+  it('returns a mongo client', () => {
+    process.env.MONGODB_IS_AWS = 'false'
+    const connect = require('mongo.js').default // eslint-disable-line global-require
+    connect()
+    expect(monk).toHaveBeenCalledWith("mongodb://sinopia:sekret@localhost:27017/sinopia_repository", {"useUnifiedTopology": true})
+  })
+})

--- a/src/mongo.js
+++ b/src/mongo.js
@@ -13,7 +13,6 @@ let db
 const connect = () => {
   if(!db) db = isAws ? awsConnect() : mongoConnect()
   return db
-
 }
 
 const awsConnect = () => {


### PR DESCRIPTION
## Why was this change made?

Part of #4 

As noted in the comment, do to ENV and mock resets, the two tests need to be in separate files to avoid inconsistent setting/resetting.

## How was this change tested?

Unit

## Which documentation and/or configurations were updated?

N/A


