### PR TITLE
Fix to copyResources.js

### DIFF
--- a/copyResources.js
+++ b/copyResources.js
@@ -18,7 +18,7 @@ class ResourcesCopier {
       /* eslint-disable no-await-in-loop */
       /* eslint-disable no-continue */
       console.log(`Fetching ${nextUrl}`)
-      const page = await this.fetchPage(nextUrl)
+      const page = await ResourcesCopier.fetchPage(nextUrl)
       for(const resource of page.data) {
         // Don't copy base templates
         if(resource.uri.includes('resource/sinopia:template')) continue;


### PR DESCRIPTION
## Why was this change made?
I broke it making lint fixes:
```
$ bin/copy https://api.development.sinopia.io http://localhost:3000
Fetching https://api.development.sinopia.io/resource
TypeError: this.fetchPage is not a function
    at ResourcesCopier.copy (file:///Users/jlittman/data/ld4p/sinopia_api/copyResources.js:21:31)
    at copyResources (file:///Users/jlittman/data/ld4p/sinopia_api/copyResources.js:62:65)
    at file:///Users/jlittman/data/ld4p/sinopia_api/copyResources.js:69:1
    at ModuleJob.run (internal/modules/esm/module_job.js:138:23)
    at async Loader.import (internal/modules/esm/loader.js:178:24)
```


## How was this change tested?
Locally.


## Which documentation and/or configurations were updated?
NA



