### PR TITLE
Fix N3 writer import.

### DIFF
--- a/src/rdf.js
+++ b/src/rdf.js
@@ -1,4 +1,4 @@
-import { Writer } from 'n3';
+import Writer from 'n3/lib/N3Writer.js'
 import rdf from 'rdf-ext'
 import { Readable } from 'stream'
 import ParserJsonld from '@rdfjs/parser-jsonld'


### PR DESCRIPTION
## Why was this change made?
So that the container will start up without:
```
api_1            | 
api_1            | > sinopia_api@0.1.0 start /home/circleci
api_1            | > node src/server.js
api_1            | 
api_1            | file:///home/circleci/src/rdf.js:1
api_1            | import { Writer } from 'n3';
api_1            |          ^^^^^^
api_1            | SyntaxError: The requested module 'n3' is expected to be of type CommonJS, which does not support named exports. CommonJS modules can be imported by importing the default export.
api_1            | For example:
api_1            | import pkg from 'n3';
api_1            | const { Writer } = pkg;
api_1            |     at ModuleJob._instantiate (internal/modules/esm/module_job.js:98:21)
api_1            |     at async ModuleJob.run (internal/modules/esm/module_job.js:137:5)
api_1            |     at async Loader.import (internal/modules/esm/loader.js:165:24)
api_1            |     at async Object.loadESM (internal/process/esm_loader.js:68:5)
api_1            | npm ERR! code ELIFECYCLE
api_1            | npm ERR! errno 1
api_1            | npm ERR! sinopia_api@0.1.0 start: `node src/server.js`
api_1            | npm ERR! Exit status 1
api_1            | npm ERR! 
api_1            | npm ERR! Failed at the sinopia_api@0.1.0 start script.
api_1            | npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
api_1            | 
api_1            | npm ERR! A complete log of this run can be found in:
api_1            | npm ERR!     /home/circleci/.npm/_logs/2020-10-08T13_12_28_165Z-debug.log
```


## How was this change tested?
Locally.


## Which documentation and/or configurations were updated?
NA



