### PR TITLE
remove version specification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "sinopia_api",
-  "version": "1.1.10",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "sinopia_api",
-  "version": "1.1.10",
   "description": "API for persisting resources in the Sinopia framework.",
   "main": "src/server.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Why was this change made?

since we don't intend to keep publishing this for consumption, and since we tend not to update package.json version when we tag a new release for weekly dependency update deployment.

i'll note that `npm i` didn't give any warnings or errors when i omitted the version, unlike when i tried to use a version other than `MAJOR.MINOR.PATCH` with only numeric values for each part.  e.g. `npm i` warned about `2`, `2.1`, and `2.1.x`:
* `npm WARN Invalid version: "2.1"`
* `npm WARN Invalid version: "2.1.x"`
* `npm WARN Invalid version: "2"`

discussed with @jermnelson and he voted for just omitting the version.

ref https://github.com/LD4P/sinopia/issues/316

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

`package[-lock].json`


