### PR TITLE
manual weekly dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -292,9 +292,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.5.tgz",
-      "integrity": "sha512-Uq9z2e7ZtcnDMirRqAGLRaLwJn+Lrh388v5ETrR3pALJnElVh2zqQmdbz4W2RUJYohAPh2mtyPUgyMHMzXMncQ==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz",
+      "integrity": "sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.14.5",
@@ -370,9 +370,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-          "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
           "dev": true
         },
         "@babel/template": {
@@ -559,9 +559,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-          "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
           "dev": true
         },
         "@babel/template": {
@@ -576,9 +576,9 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
-          "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+          "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.14.5",
@@ -586,7 +586,7 @@
             "@babel/helper-function-name": "^7.14.5",
             "@babel/helper-hoist-variables": "^7.14.5",
             "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/parser": "^7.14.5",
+            "@babel/parser": "^7.14.7",
             "@babel/types": "^7.14.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
@@ -1368,9 +1368,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-          "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
           "dev": true
         },
         "@babel/template": {
@@ -1385,9 +1385,9 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
-          "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+          "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.14.5",
@@ -1395,7 +1395,7 @@
             "@babel/helper-function-name": "^7.14.5",
             "@babel/helper-hoist-variables": "^7.14.5",
             "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/parser": "^7.14.5",
+            "@babel/parser": "^7.14.7",
             "@babel/types": "^7.14.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
@@ -1680,23 +1680,23 @@
       }
     },
     "@babel/node": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.14.5.tgz",
-      "integrity": "sha512-fwAf0Ba3gjcwP04T0BD0Y3oHOTDQH2tVcyaPOMjb+8xkCJ38FoaVOlLfQ/asBgm6aCkBkn12/l8spCXUEEeAyA==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.14.7.tgz",
+      "integrity": "sha512-QghINtVgOUCrSpE7z4IXPTGJfRYyjoY7ny5Qz0cuUlsThQv6WSn1xJk217WlEDucPLP2o5HwGXPSkxD4LWOZxQ==",
       "dev": true,
       "requires": {
         "@babel/register": "^7.14.5",
         "commander": "^4.0.1",
-        "core-js": "^3.14.0",
+        "core-js": "^3.15.0",
         "node-environment-flags": "^1.0.5",
         "regenerator-runtime": "^0.13.4",
         "v8flags": "^3.1.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.14.0.tgz",
-          "integrity": "sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA==",
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+          "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==",
           "dev": true
         }
       }
@@ -1726,9 +1726,9 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.5.tgz",
-      "integrity": "sha512-tbD/CG3l43FIXxmu4a7RBe4zH7MLJ+S/lFowPFO7HetS2hyOZ/0nnnznegDuzFzfkyQYTxqdTH/hKmuBngaDAA==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.7.tgz",
+      "integrity": "sha512-RK8Wj7lXLY3bqei69/cc25gwS5puEc3dknoFPFbqfy3XxYQBQFvu4ioWpafMBAB+L9NyptQK4nMOa5Xz16og8Q==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -1890,18 +1890,24 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.5.tgz",
-      "integrity": "sha512-VzMyY6PWNPPT3pxc5hi9LloKNr4SSrVCg7Yr6aZpW4Ym07r7KqSU/QXYwjXLVxqwSv0t/XSXkFoKBPUkZ8vb2A==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
+      "integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/compat-data": "^7.14.7",
         "@babel/helper-compilation-targets": "^7.14.5",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-parameters": "^7.14.5"
       },
       "dependencies": {
+        "@babel/compat-data": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+          "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+          "dev": true
+        },
         "@babel/helper-plugin-utils": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
@@ -2369,9 +2375,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-          "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
           "dev": true
         },
         "@babel/template": {
@@ -2450,9 +2456,9 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.5.tgz",
-      "integrity": "sha512-wU9tYisEbRMxqDezKUqC9GleLycCRoUsai9ddlsq54r8QRLaeEhc+d+9DqCG+kV9W2GgQjTZESPTpn5bAFMDww==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+      "integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -2599,9 +2605,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-          "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
           "dev": true
         },
         "@babel/template": {
@@ -2781,9 +2787,9 @@
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.5.tgz",
-      "integrity": "sha512-+Xe5+6MWFo311U8SchgeX5c1+lJM+eZDBZgD+tvXu9VVQPXwwVzeManMMjYX6xw2HczngfOSZjoFYKwdeB/Jvw==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.7.tgz",
+      "integrity": "sha512-DTNOTaS7TkW97xsDMrp7nycUVh6sn/eq22VaxWfEdzuEbRsiaOU0pqU7DlyUGHVsbQbSghvjKRpEl+nUCKGQSg==",
       "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.14.5"
@@ -2902,9 +2908,9 @@
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.5.tgz",
-      "integrity": "sha512-/3iqoQdiWergnShZYl0xACb4ADeYCJ7X/RgmwtXshn6cIvautRPAFzhd58frQlokLO6Jb4/3JXvmm6WNTPtiTw==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
+      "integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -3006,17 +3012,17 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.5.tgz",
-      "integrity": "sha512-ci6TsS0bjrdPpWGnQ+m4f+JSSzDKlckqKIJJt9UZ/+g7Zz9k0N8lYU8IeLg/01o2h8LyNZDMLGgRLDTxpudLsA==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.7.tgz",
+      "integrity": "sha512-itOGqCKLsSUl0Y+1nSfhbuuOlTs0MJk2Iv7iSH+XT/mR8U1zRLO7NjWlYXB47yhK4J/7j+HYty/EhFZDYKa/VA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/compat-data": "^7.14.7",
         "@babel/helper-compilation-targets": "^7.14.5",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
-        "@babel/plugin-proposal-async-generator-functions": "^7.14.5",
+        "@babel/plugin-proposal-async-generator-functions": "^7.14.7",
         "@babel/plugin-proposal-class-properties": "^7.14.5",
         "@babel/plugin-proposal-class-static-block": "^7.14.5",
         "@babel/plugin-proposal-dynamic-import": "^7.14.5",
@@ -3025,7 +3031,7 @@
         "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
         "@babel/plugin-proposal-numeric-separator": "^7.14.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.14.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
         "@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
         "@babel/plugin-proposal-optional-chaining": "^7.14.5",
         "@babel/plugin-proposal-private-methods": "^7.14.5",
@@ -3051,7 +3057,7 @@
         "@babel/plugin-transform-block-scoping": "^7.14.5",
         "@babel/plugin-transform-classes": "^7.14.5",
         "@babel/plugin-transform-computed-properties": "^7.14.5",
-        "@babel/plugin-transform-destructuring": "^7.14.5",
+        "@babel/plugin-transform-destructuring": "^7.14.7",
         "@babel/plugin-transform-dotall-regex": "^7.14.5",
         "@babel/plugin-transform-duplicate-keys": "^7.14.5",
         "@babel/plugin-transform-exponentiation-operator": "^7.14.5",
@@ -3063,7 +3069,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.14.5",
         "@babel/plugin-transform-modules-systemjs": "^7.14.5",
         "@babel/plugin-transform-modules-umd": "^7.14.5",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.5",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.7",
         "@babel/plugin-transform-new-target": "^7.14.5",
         "@babel/plugin-transform-object-super": "^7.14.5",
         "@babel/plugin-transform-parameters": "^7.14.5",
@@ -3071,7 +3077,7 @@
         "@babel/plugin-transform-regenerator": "^7.14.5",
         "@babel/plugin-transform-reserved-words": "^7.14.5",
         "@babel/plugin-transform-shorthand-properties": "^7.14.5",
-        "@babel/plugin-transform-spread": "^7.14.5",
+        "@babel/plugin-transform-spread": "^7.14.6",
         "@babel/plugin-transform-sticky-regex": "^7.14.5",
         "@babel/plugin-transform-template-literals": "^7.14.5",
         "@babel/plugin-transform-typeof-symbol": "^7.14.5",
@@ -3082,10 +3088,16 @@
         "babel-plugin-polyfill-corejs2": "^0.2.2",
         "babel-plugin-polyfill-corejs3": "^0.2.2",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
-        "core-js-compat": "^3.14.0",
+        "core-js-compat": "^3.15.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "@babel/compat-data": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+          "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+          "dev": true
+        },
         "@babel/helper-plugin-utils": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
@@ -3589,6 +3601,14 @@
       "integrity": "sha512-6ITWcu2sr9zJqXUPDm1XJ8DRpea7PotWBIkTzuO1MCSruLOWH2ICoQOAtlJy30cT+GqH9oAQKPR+CHXejsdizA==",
       "requires": {
         "@types/rdf-js": "*"
+      }
+    },
+    "@rdfjs/dataset": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
+      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
+      "requires": {
+        "@rdfjs/data-model": "^1.2.0"
       }
     },
     "@rdfjs/parser-jsonld": {
@@ -4207,9 +4227,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.931.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.931.0.tgz",
-      "integrity": "sha512-Db97/aJq8zYl8mHzY6dNO6m9S89TqN4HEUUc2aCYQCTyMb/eNrjf+uZTnutnQbJkClqHzxFcWc3aqe5VlTac/A==",
+      "version": "2.937.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.937.0.tgz",
+      "integrity": "sha512-Ko5fATHxfHWMVJjS5/7eNEeIZ0Sja3B5f7ZvdyGmyRdUv7JVeppkNmc6cK5jFt/qGxVOK2OZnY/vE6D/INwGiQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -4310,13 +4330,13 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.2.tgz",
-      "integrity": "sha512-l1Cf8PKk12eEk5QP/NQ6TH8A1pee6wWDJ96WjxrMXFLHLOBFzYM4moG80HFgduVhTqAFez4alnZKEhP/bYHg0A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.3.tgz",
+      "integrity": "sha512-rCOFzEIJpJEAU14XCcV/erIf/wZQMmMT5l5vXOpL5uoznyOGfDIjPj6FVytMvtzaKSTSVKouOCTPJ5OMUZH30g==",
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "core-js-compat": "^3.9.1"
+        "core-js-compat": "^3.14.0"
       }
     },
     "babel-plugin-polyfill-regenerator": {
@@ -5305,9 +5325,9 @@
       "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.14.0.tgz",
-      "integrity": "sha512-R4NS2eupxtiJU+VwgkF9WTpnSfZW4pogwKHd8bclWU2sp93Pr5S1uYJI84cMOubJRou7bcfL0vmwtLslWN5p3A==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.2.tgz",
+      "integrity": "sha512-Wp+BJVvwopjI+A1EFqm2dwUmWYXrvucmtIB2LgXn/Rb+gWPKYxtmb4GKHGKG/KGF1eK9jfjzT38DITbTOCX/SQ==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.6",
@@ -7512,9 +7532,9 @@
       "dev": true
     },
     "is-path-inside": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
     "is-plain-object": {
@@ -9247,9 +9267,9 @@
       "dev": true
     },
     "nodemon": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.7.tgz",
-      "integrity": "sha512-XHzK69Awgnec9UzHr1kc8EomQh4sjTQ8oRf8TsGrSmHDx9/UmiGG9E/mM3BuTfNeFwdNBvrqQq/RHL0xIeyFOA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.9.tgz",
+      "integrity": "sha512-6O4k7C8f2HQArGpaPBOqGGddjzDLQAqCYmq3tKMeNIbz7Is/hOphMHy2dcY10sSq5wl3cqyn9Iz+Ep2j51JOLg==",
       "dev": true,
       "requires": {
         "chokidar": "^3.2.2",
@@ -10265,13 +10285,16 @@
         }
       }
     },
-    "rdf-dataset-indexed": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/rdf-dataset-indexed/-/rdf-dataset-indexed-0.4.0.tgz",
-      "integrity": "sha512-xIZ3PGwBHh1DVax9FTq/zhJcrdJTkCgRT2xolF5ZhKj0EOFoT6wdITyfxKSmnD6YNyGyng5F5o2SR62TYask3Q==",
+    "rdf-ext": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-ext/-/rdf-ext-1.3.2.tgz",
+      "integrity": "sha512-4udPgHLnlkkOjCJiZ0XEpzhjsAkgNo+9+IJ7nh48V8+O/oqMPKUZn6HoVCanyiV4/WGKQGx89YNtnNk6NOBAFQ==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "readable-stream": "^3.3.0"
+        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/dataset": "^1.1.1",
+        "@rdfjs/to-ntriples": "^1.0.1",
+        "rdf-normalize": "^1.0.0",
+        "readable-stream": "^3.6.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -10284,17 +10307,6 @@
             "util-deprecate": "^1.0.1"
           }
         }
-      }
-    },
-    "rdf-ext": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rdf-ext/-/rdf-ext-1.3.1.tgz",
-      "integrity": "sha512-mdkmEULWtKV9t5EHfnAxM2zL4xiloiSrEZnDtsBsVEpR4kk7teUfhotaXBzW5J1EHZSq5KcZ5VmJsUFZljLMSw==",
-      "requires": {
-        "@rdfjs/data-model": "^1.1.0",
-        "@rdfjs/to-ntriples": "^1.0.1",
-        "rdf-dataset-indexed": "^0.4.0",
-        "rdf-normalize": "^1.0.0"
       }
     },
     "rdf-normalize": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "type": "module",
   "dependencies": {
     "@rdfjs/parser-jsonld": "^1.2.1",
-    "aws-sdk": "^2.931.0",
+    "aws-sdk": "^2.937.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-jwt": "^6.0.0",
@@ -32,20 +32,20 @@
     "lodash": "^4.17.21",
     "monk": "^7.3.4",
     "n3": "^1.9.0",
-    "rdf-ext": "^1.3.1",
+    "rdf-ext": "^1.3.2",
     "redoc-cli": "^0.9.13",
     "superagent": "^6.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",
-    "@babel/node": "^7.14.5",
-    "@babel/preset-env": "^7.14.5",
+    "@babel/node": "^7.14.7",
+    "@babel/preset-env": "^7.14.7",
     "amazon-cognito-identity-js": "^4.6.3",
     "babel-jest": "^26.6.3",
     "eslint": "^7.29.0",
     "jest": "^26.6.3",
     "node-fetch": "^2.6.1",
-    "nodemon": "^2.0.7",
+    "nodemon": "^2.0.9",
     "openapi-enforcer-cli": "^0.3.7",
     "prompt": "^1.0.0",
     "supertest": "^4.0.2"


### PR DESCRIPTION
## Why was this change made?

didn't get auto-generated for some reason (though the version bumps are much the same as the ones for the sinopia apps earlier this week, so i don't think this is a case of new dependency releases happening since monday morning, or at least not entirely).

## How was this change tested?

unit


## Which documentation and/or configurations were updated?

`package.json` and `package-lock.json`
