### PR TITLE
Code coverage added, including CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,24 @@ jobs:
             echo $result
             exit 1
             }
+  test:
+    executor: default
+    steps:
+      - checkout
+      - node/install-packages
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+            ./cc-test-reporter before-build
+      - run:
+          name: Run tests
+          command: npm run test
+      - run:
+          name: Send coverage report to Code Climate
+          command: |
+            ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
   deploy-ecs:
     parameters:
       role-arn:
@@ -86,8 +104,7 @@ jobs:
 workflows:
   build:
     jobs:
-      - node/test:
-          name: test
+      - test:
           filters:
             <<: *branch_only_filter
       - node/run:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/LD4P/sinopia_api/main/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/LD4P/sinopia_api/main/openapi.yml)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/8cfcf854f776a8c16e4a/test_coverage)](https://codeclimate.com/github/LD4P/sinopia_api/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8cfcf854f776a8c16e4a/maintainability)](https://codeclimate.com/github/LD4P/sinopia_api/maintainability)
+[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/ld4p/sinopia_api?sort=semver)](https://hub.docker.com/repository/docker/ld4p/sinopia_api/tags?page=1&ordering=last_updated)
 
 # Sinopia API
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![CircleCI](https://circleci.com/gh/LD4P/sinopia_api.svg?style=svg)](https://circleci.com/gh/LD4P/sinopia_api)
 [![Docker image](https://images.microbadger.com/badges/image/ld4p/sinopia_api.svg)](https://microbadger.com/images/ld4p/sinopia_api "Get your own image badge on microbadger.com")
 [![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/LD4P/sinopia_api/main/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/LD4P/sinopia_api/main/openapi.yml)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/8cfcf854f776a8c16e4a/test_coverage)](https://codeclimate.com/github/LD4P/sinopia_api/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/8cfcf854f776a8c16e4a/maintainability)](https://codeclimate.com/github/LD4P/sinopia_api/maintainability)
 
 # Sinopia API
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "setupFiles": [
       "<rootDir>/jest.envVars.js"
     ],
-    "clearMocks": true
+    "clearMocks": true,
+    "collectCoverage": true,
+    "coverageReporters": ["lcov"]
   }
 }


### PR DESCRIPTION
## Why was this change made?

code coverage, and its badges, are a good thing

Closes #9

### coverage stats won't show until its merged to main

### orbs

I looked for an orb for codeclimate, and there are several.  None are official from circleci or from code climate.  None have more than 25 users.  So I opted to go with an old style job that uses the node orb.
 

## How was this change tested?

circleci reports to codeclimate;  maintenance info shows up.

## Which documentation and/or configurations were updated?




