### PR TITLE
notify hb on 500 only

### DIFF
--- a/__tests__/error.test.js
+++ b/__tests__/error.test.js
@@ -1,0 +1,42 @@
+import request from 'supertest'
+import app from 'app.js'
+import connect from 'mongo.js'
+import Honeybadger from '@honeybadger-io/js'
+
+// Configure bogus HB key for tests only
+Honeybadger.configure({
+  apiKey: 'bogus'
+})
+
+jest.mock('mongo.js')
+jest.mock('@honeybadger-io/js')
+
+describe('500 Server error', () => {
+  it('returns server error and notifies HB', async () => {
+    connect.mockImplementation(() => {
+      throw new Error('Ooops')
+     })
+    const res = await request(app)
+      .get('/user/nchomsky')
+      .send()
+    expect(Honeybadger.notify).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toEqual(500)
+    expect(res.body).toEqual([{"details": "Error: Ooops", "code": "500", "title": "Server error"}])
+  })
+})
+
+describe('404 Server error', () => {
+  it('returns server error and does not notify HB', async () => {
+    connect.mockImplementation(() => {
+      const err = new Error('Not Found');
+      err.status = 404;
+      throw err
+     })
+    const res = await request(app)
+      .get('/user/nchomsky')
+      .send()
+    expect(Honeybadger.notify).toHaveBeenCalledTimes(0)
+    expect(res.statusCode).toEqual(404)
+    expect(res.body).toEqual([{"details": "Error: Not Found", "code": "404", "title": "Not Found"}])
+  })
+})

--- a/src/app.js
+++ b/src/app.js
@@ -15,9 +15,9 @@ const app = express()
 
 // Use HB before all other app middleware.
 Honeybadger.configure({
-  apiKey: process.env.HONEYBADGER_API_KEY
+  apiKey: process.env.HONEYBADGER_API_KEY,
+  environment: process.env.HONEYBADGER_ENV
 })
-app.use(Honeybadger.requestHandler)
 
 app.use(function (req, res, next) {
   if(process.env.NODE_ENV === 'development') console.log(`${req.method} ${req.url}`)
@@ -71,7 +71,6 @@ app.use('/user', usersRouter)
 
 // Error handlers
 // Use HB before all other error handlers.
-app.use(Honeybadger.errorHandler)
 app.use(mongoErrorAdapter)
 app.use(s3ErrorAdapter)
 app.use(errorHandler)

--- a/src/error.js
+++ b/src/error.js
@@ -1,4 +1,5 @@
 import createError from 'http-errors'
+import Honeybadger from '@honeybadger-io/js'
 
 export const errorHandler = (err, req, res, next) => {
   console.error(`Error for ${req.originalUrl}`, err)
@@ -11,6 +12,7 @@ export const errorHandler = (err, req, res, next) => {
   } else if (err.status) {
     res.status(err.status).send([{title: err.message, details: err.toString(), code: err.status.toString()}])
   } else {
+    Honeybadger.notify(err);
     res.status(500).send([{title: 'Server error', details: err.toString(), code: '500'}])
   }
 }


### PR DESCRIPTION
## Why was this change made?

Fixes #165 - only send alerts to HB on 500 errors

## How was this change tested?

Stole test from https://github.com/LD4P/sinopia_api/pull/159/files#diff-36e1c5a25ea40111a32895d5b7ef131596943c0e4c77b8d93cf79b9beaef196b and updated to add HB expectation testing


## Which documentation and/or configurations were updated?




