### PR TITLE
add edit_groups to resource metadata

### DIFF
--- a/__tests__/__fixtures__/all_resp.json
+++ b/__tests__/__fixtures__/all_resp.json
@@ -4,9 +4,7 @@
       "data": [
         {
           "@id": "https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041",
-          "@type": [
-            "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-          ],
+          "@type": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
           "http://id.loc.gov/ontologies/bibframe/mainTitle": [
             {
               "@language": "eng",
@@ -26,9 +24,8 @@
       "bfItemRefs": [],
       "bfWorkRefs": [],
       "group": "stanford",
-      "types": [
-        "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-      ],
+      "edit_groups": ["stanford"],
+      "types": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
       "templateId": "profile:bf2:Title:AbbrTitle",
       "id": "6852a770-2961-4836-a833-0b21a9b68041",
       "uri": "https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041",
@@ -38,9 +35,7 @@
       "data": [
         {
           "@id": "http://api.development.sinopia.io/resource/63834c19-4d01-4c91-9dcc-a69c6e26c886",
-          "@type": [
-            "http://id.loc.gov/ontologies/bibframe/Work"
-          ],
+          "@type": ["http://id.loc.gov/ontologies/bibframe/Work"],
           "http://www.w3.org/2002/07/owl#sameAs": [
             {
               "@id": "repository/washington/37ec8045-aa1a-46c2-9068-db7579b0c784"
@@ -49,9 +44,7 @@
         },
         {
           "@id": "http://api.development.sinopia.io/resource/63834c19-4d01-4c91-9dcc-a69c6e26c886",
-          "@type": [
-            "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-          ],
+          "@type": ["http://id.loc.gov/ontologies/bibframe/AdminMetadata"],
           "http://id.loc.gov/ontologies/bflc/encodingLevel": [
             {
               "@id": "http://id.loc.gov/vocabulary/menclvl/3"
@@ -99,9 +92,8 @@
       "bfItemRefs": [],
       "bfWorkRefs": [],
       "group": "yale",
-      "types": [
-        "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-      ],
+      "edit_groups": ["yale"],
+      "types": ["http://id.loc.gov/ontologies/bibframe/AdminMetadata"],
       "user": "tat2",
       "timestamp": "2019-11-08T17:40:23.363Z",
       "templateId": "Yale:RT:BF2:AdminMetadata",

--- a/__tests__/__fixtures__/metadata_6852a770-2961-4836-a833-0b21a9b68041.json
+++ b/__tests__/__fixtures__/metadata_6852a770-2961-4836-a833-0b21a9b68041.json
@@ -5,6 +5,7 @@
       "timestamp": "2020-08-20T11:34:40.887Z",
       "user": "havram",
       "group": "stanford",
+      "edit_groups": ["stanford"],
       "templateId": "profile:bf2:Title:AbbrTitle"
     }
   ]

--- a/__tests__/__fixtures__/page_one_resp.json
+++ b/__tests__/__fixtures__/page_one_resp.json
@@ -4,9 +4,7 @@
       "data": [
         {
           "@id": "https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041",
-          "@type": [
-            "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-          ],
+          "@type": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
           "http://id.loc.gov/ontologies/bibframe/mainTitle": [
             {
               "@language": "eng",
@@ -26,9 +24,8 @@
       "bfItemRefs": [],
       "bfWorkRefs": [],
       "group": "stanford",
-      "types": [
-        "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-      ],
+      "edit_groups": ["stanford"],
+      "types": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
       "templateId": "profile:bf2:Title:AbbrTitle",
       "id": "6852a770-2961-4836-a833-0b21a9b68041",
       "uri": "https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041",

--- a/__tests__/__fixtures__/req_6852a770-2961-4836-a833-0b21a9b68041.json
+++ b/__tests__/__fixtures__/req_6852a770-2961-4836-a833-0b21a9b68041.json
@@ -2,9 +2,7 @@
   "data": [
     {
       "@id": "https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041",
-      "@type": [
-        "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-      ],
+      "@type": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
       "http://id.loc.gov/ontologies/bibframe/mainTitle": [
         {
           "@value": "foo",
@@ -24,9 +22,8 @@
   "bfItemRefs": [],
   "bfWorkRefs": [],
   "group": "stanford",
-  "types": [
-    "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-  ],
+  "edit_groups": ["stanford"],
+  "types": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
   "templateId": "profile:bf2:Title:AbbrTitle",
   "timestamp": "2020-08-20T11:34:40.887Z",
   "id": "6852a770-2961-4836-a833-0b21a9b68041",

--- a/__tests__/__fixtures__/resource_63834c19-4d01-4c91-9dcc-a69c6e26c886.json
+++ b/__tests__/__fixtures__/resource_63834c19-4d01-4c91-9dcc-a69c6e26c886.json
@@ -2,9 +2,7 @@
   "data": [
     {
       "@id": "http://api.development.sinopia.io/resource/63834c19-4d01-4c91-9dcc-a69c6e26c886",
-      "@type": [
-        "http://id.loc.gov/ontologies/bibframe/Work"
-      ],
+      "@type": ["http://id.loc.gov/ontologies/bibframe/Work"],
       "http://www.w3.org/2002/07/owl#sameAs": [
         {
           "@id": "repository/washington/37ec8045-aa1a-46c2-9068-db7579b0c784"
@@ -13,9 +11,7 @@
     },
     {
       "@id": "http://api.development.sinopia.io/resource/63834c19-4d01-4c91-9dcc-a69c6e26c886",
-      "@type": [
-        "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-      ],
+      "@type": ["http://id.loc.gov/ontologies/bibframe/AdminMetadata"],
       "http://id.loc.gov/ontologies/bflc/encodingLevel": [
         {
           "@id": "http://id.loc.gov/vocabulary/menclvl/3"
@@ -63,9 +59,8 @@
   "bfItemRefs": [],
   "bfWorkRefs": [],
   "group": "yale",
-  "types": [
-    "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-  ],
+  "edit_groups": ["yale"],
+  "types": ["http://id.loc.gov/ontologies/bibframe/AdminMetadata"],
   "user": "tat2",
   "timestamp": "2019-11-08T17:40:23.363Z",
   "templateId": "Yale:RT:BF2:AdminMetadata",

--- a/__tests__/__fixtures__/resource_6852a770-2961-4836-a833-0b21a9b68041.json
+++ b/__tests__/__fixtures__/resource_6852a770-2961-4836-a833-0b21a9b68041.json
@@ -2,9 +2,7 @@
   "data": [
     {
       "@id": "https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041",
-      "@type": [
-        "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-      ],
+      "@type": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
       "http://id!loc!gov/ontologies/bibframe/mainTitle": [
         {
           "@value": "foo",
@@ -24,9 +22,8 @@
   "bfItemRefs": [],
   "bfWorkRefs": [],
   "group": "stanford",
-  "types": [
-    "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-  ],
+  "edit_groups": ["stanford"],
+  "types": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
   "templateId": "profile:bf2:Title:AbbrTitle",
   "id": "6852a770-2961-4836-a833-0b21a9b68041",
   "uri": "https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041",

--- a/__tests__/__fixtures__/resp_6852a770-2961-4836-a833-0b21a9b68041.json
+++ b/__tests__/__fixtures__/resp_6852a770-2961-4836-a833-0b21a9b68041.json
@@ -2,9 +2,7 @@
   "data": [
     {
       "@id": "https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041",
-      "@type": [
-        "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-      ],
+      "@type": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
       "http://id.loc.gov/ontologies/bibframe/mainTitle": [
         {
           "@value": "foo",
@@ -24,9 +22,8 @@
   "bfItemRefs": [],
   "bfWorkRefs": [],
   "group": "stanford",
-  "types": [
-    "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
-  ],
+  "edit_groups": ["stanford"],
+  "types": ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
   "templateId": "profile:bf2:Title:AbbrTitle",
   "timestamp": "2020-08-20T11:34:40.887Z",
   "id": "6852a770-2961-4836-a833-0b21a9b68041",

--- a/__tests__/endpoints/resourcePut.test.js
+++ b/__tests__/endpoints/resourcePut.test.js
@@ -61,6 +61,7 @@ describe('PUT /resource/:resourceId', () => {
       "timestamp": new Date(),
       "user": "havram",
       "group": "stanford",
+      "edit_groups": ["stanford"],
       "templateId": "profile:bf2:Title:AbbrTitle"
     }
     expect(mockResourceMetadataUpdate).toHaveBeenCalledWith({id: '6852a770-2961-4836-a833-0b21a9b68041'}, { $push: { versions: versionEntry}})

--- a/openapi.yml
+++ b/openapi.yml
@@ -91,7 +91,7 @@ paths:
             default: 1
         - name: group
           description: Group name filter. For values, see /groups endpoint.
-          example: stanford
+          example: "stanford"
           in: query
           required: false
           schema:
@@ -113,7 +113,7 @@ paths:
             type: string
         - name: type
           description: Class filter
-          example: http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle
+          example: "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"
           in: query
           required: false
           schema:
@@ -187,7 +187,7 @@ paths:
           content:
             application/json:
               schema:
-                    $ref: '#/components/schemas/Errors'
+                $ref: '#/components/schemas/Errors'
       parameters:
         - name: resourceId
           in: path
@@ -224,7 +224,7 @@ paths:
           content:
             application/json:
               schema:
-                    $ref: '#/components/schemas/Errors'
+                $ref: '#/components/schemas/Errors'
       parameters:
         - name: resourceId
           in: path
@@ -257,7 +257,7 @@ paths:
           content:
             application/json:
               schema:
-                    $ref: '#/components/schemas/Errors'
+                $ref: '#/components/schemas/Errors'
       parameters:
         - name: resourceId
           in: path
@@ -278,12 +278,12 @@ paths:
               schema:
                 type: object
       parameters:
-            - name: resourceId
-              in: path
-              description: ID of the resource
-              required: true
-              schema:
-                type: string
+        - name: resourceId
+          in: path
+          description: ID of the resource
+          required: true
+          schema:
+            type: string
   /resource/{resourceId}/version/{timestamp}:
     get:
       summary: Return specified version of the resource.
@@ -418,7 +418,7 @@ paths:
           content:
             application/json:
               schema:
-                    $ref: '#/components/schemas/Errors'
+                $ref: '#/components/schemas/Errors'
       parameters:
         - name: resourceId
           in: path
@@ -455,7 +455,7 @@ paths:
           content:
             application/json:
               schema:
-                    $ref: '#/components/schemas/Errors'
+                $ref: '#/components/schemas/Errors'
       parameters:
         - name: userId
           in: path
@@ -492,7 +492,7 @@ paths:
           content:
             application/json:
               schema:
-                    $ref: '#/components/schemas/Errors'
+                $ref: '#/components/schemas/Errors'
       parameters:
         - name: userId
           in: path
@@ -525,7 +525,7 @@ paths:
           content:
             application/json:
               schema:
-                    $ref: '#/components/schemas/Errors'
+                $ref: '#/components/schemas/Errors'
       parameters:
         - name: userId
           in: path
@@ -585,7 +585,7 @@ components:
         properties:
           title:
             type: string
-          details: 
+          details:
             type: string
           status:
             type: string
@@ -601,9 +601,6 @@ components:
           type: array
           items:
             type: object
-        user:
-          description: Username for the user who last updated the record.
-          type: string
         bfAdminMetadataRefs:
           description: References to Bibframe AdminMetadata contained within this record.
           type: array
@@ -624,9 +621,23 @@ components:
           type: array
           items:
             type: string
+        edit_groups:
+          description: Groups whose members can edit this record.
+          type: array
+          items:
+            type: string
         group:
           description: The group to which the record belongs.
           type: string
+        id:
+          description: The identifier for the resource, which is the final section of the URI.
+          example: "6852a770-2961-4836-a833-0b21a9b68041"
+          type: string
+        timestamp:
+          description: The date and time the resource was last updated. This also identifies the resource version.
+          example: "2020-08-20T11:34:40.887Z"
+          type: string
+          format: date-time
         types:
           description: The classes for the record.
           example:
@@ -634,28 +645,22 @@ components:
           type: array
           items:
             type: string
-        id:
-          description: The identifier for the resource, which is the final section of the URI.
-          example: 6852a770-2961-4836-a833-0b21a9b68041
-          type: string
         uri:
           description: The URI for the resource.
-          example: https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041
+          example: "https://api.development.sinopia.io/resource/6852a770-2961-4836-a833-0b21a9b68041"
           type: string
-        timestamp:
-          description: The date and time the resource was last updated. This also identifies the resource version.
-          example: "2020-08-20T11:34:40.887Z"
+        user:
+          description: Username for the user who last updated the record.
           type: string
-          format: date-time
       required:
         - data
-        - user
         - bfAdminMetadataRefs
         - bfItemRefs
         - bfInstanceRefs
         - bfWorkRefs
         - group
         - types
+        - user
     ResourcePage:
       description: Response containing a page of resource records.
       type: object
@@ -696,11 +701,11 @@ components:
               type: object
               properties:
                 template:
-                  $ref: "#/components/schemas/History"
+                  $ref: '#/components/schemas/History'
                 resource:
-                  $ref: "#/components/schemas/History"
+                  $ref: '#/components/schemas/History'
                 search:
-                  $ref: "#/components/schemas/History"
+                  $ref: '#/components/schemas/History'
               required:
                 - template
                 - resource

--- a/src/endpoints/resources.js
+++ b/src/endpoints/resources.js
@@ -221,6 +221,7 @@ const versionEntry = (resource) => ({
   timestamp: resource.timestamp,
   user: resource.user,
   group: resource.group,
+  edit_groups: resource.edit_groups, // eslint-disable-line camelcase
   templateId: resource.templateId
 })
 


### PR DESCRIPTION
## Why was this change made?

Resources need edit_groups to facilitate cooperative cataloging.

Fixes #139 

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?




