### PR TITLE
validate resource is json-ld parseable for POST/PUT

### DIFF
--- a/__tests__/endpoints/resourcePost.test.js
+++ b/__tests__/endpoints/resourcePost.test.js
@@ -67,6 +67,23 @@ describe('POST /resource/:resourceId', () => {
       .send(reqBody)
     expect(res.statusCode).toEqual(401)
   })
+  it('returns 400 error if resource is unparseable', async () => {
+    const reqBodyUnparseable = String(reqBody).replace('"@value"', '"@value')
+    const res = await request(app)
+      .post('/resource/6852a770-2961-4836-a833-0b21a9b68041')
+      .set('Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.fLGW-NqeXUex3gZpZW0e61zP5dmhmjNPCdBikj_7Djg')
+      .send(reqBodyUnparseable)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json')
+    expect(res.statusCode).toEqual(400)
+    expect(res.body).toEqual([
+      {
+        title: 'Bad Request',
+        details: 'Unexpected token o in JSON at position 1',
+        status: '400',
+      }
+    ])
+  })
   it('returns 409 if resource is not unique', async () => {
     const err = new Error('Ooops')
     err.code = 11000

--- a/__tests__/endpoints/resourcePut.test.js
+++ b/__tests__/endpoints/resourcePut.test.js
@@ -72,6 +72,23 @@ describe('PUT /resource/:resourceId', () => {
       .send(reqBody)
     expect(res.statusCode).toEqual(401)
   })
+  it('returns 400 error if resource is unparseable', async () => {
+    const reqBodyUnparseable = String(reqBody).replace('"@value"', '"@value')
+    const res = await request(app)
+      .post('/resource/6852a770-2961-4836-a833-0b21a9b68041')
+      .set('Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.fLGW-NqeXUex3gZpZW0e61zP5dmhmjNPCdBikj_7Djg')
+      .send(reqBodyUnparseable)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json')
+    expect(res.statusCode).toEqual(400)
+    expect(res.body).toEqual([
+      {
+        title: 'Bad Request',
+        details: 'Unexpected token o in JSON at position 1',
+        status: '400',
+      }
+    ])
+  })
   it('returns 404 when resource does not exist', async () => {
     mockResourcesUpdate.mockRejectedValue(new createError.NotFound())
     const res = await request(app)

--- a/src/endpoints/resources.js
+++ b/src/endpoints/resources.js
@@ -1,5 +1,5 @@
 import express from 'express'
-import { ttlFromJsonld, n3FromJsonld } from '../rdf.js'
+import { datasetFromJsonld, n3FromJsonld, ttlFromJsonld } from '../rdf.js'
 import _ from 'lodash'
 import createError from 'http-errors'
 
@@ -9,6 +9,8 @@ const apiBaseUrl = process.env.API_BASE_URL
 
 resourcesRouter.post('/:resourceId', (req, res, next) => {
   console.log(`Received post to ${req.params.resourceId}`)
+
+  parseJsonld(req.body.data[0])
 
   const resource = req.body
   const resourceUri = resourceUriFor(req)
@@ -36,6 +38,8 @@ resourcesRouter.post('/:resourceId', (req, res, next) => {
 
 resourcesRouter.put('/:resourceId', (req, res, next) => {
   console.log(`Received put to ${req.params.resourceId}`)
+
+  parseJsonld(req.body.data[0])
 
   const resource = req.body
   const timestamp = new Date()
@@ -197,6 +201,12 @@ const parseDate = (dateString) => {
     throw createError(400, 'Bad Request', {details: `Invalid date-time: ${dateString}`})
   }
   return date
+}
+
+const parseJsonld = (jsonldString) => {
+  datasetFromJsonld(jsonldString).catch((err) => {
+    throw createError(400, 'Bad Request', {details: `Unsparseable JSON-LD: ${err}`})
+  })
 }
 
 const forReturn = (item) => {


### PR DESCRIPTION
## Why was this change made?

fixes #136 

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?




