### PR TITLE
hardcode list of groups in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,17 @@ bin/copySingle https://api.development.sinopia.io/resource/a20ab8a5-397d-48db-a0
 
 ### Get a JWT
 
-You can use the `bin/authenticate` command-line tool to authenticate to an AWS Cognito instance. This command will create a new file called `.cognitoToken` which contains a [JSON Web Token](https://jwt.io/), which you can use to authorize HTTP requests to the Sinopia API.
+A JWT is used to make calls to sinopia_api in the context of a specific Cognito user (i.e. a user logged into Sinopia Editor). You can use the `bin/authenticate` command-line tool to authenticate to an AWS Cognito instance. This command will create a new file called `.cognitoToken` which contains a [JSON Web Token](https://jwt.io/), which you can use to authorize HTTP requests to the Sinopia API.
 
 To authenticate:
 
 ```shell
-$ AWS_PROFILE=name_of_aws_profile_used_in_~/.aws/config_file COGNITO_USER_POOL_ID=us-west-2_ABC123XYZ COGNITO_CLIENT_ID=abc123xyz456etc AWS_COGNITO_DOMAIN=https://sinopia-{ENV}.auth.us-west-2.amazoncognito.com bin/authenticate
+$ AWS_PROFILE=name_of_aws_profile_used_in_~/.aws/config COGNITO_USER_POOL_ID=us-west-2_ABC123XYZ COGNITO_CLIENT_ID=abc123xyz456etc AWS_COGNITO_DOMAIN=https://sinopia-{ENV}.auth.us-west-2.amazoncognito.com bin/authenticate
 ```
+
+The cognito user pool and client ID are available in the AWS Cognito Console for the specific environment (dev, stage or prod). The Client ID is under "App Client Settings" and the User Pool ID is under "General Settings". Possible {ENV} values in the cognito domain URL are "development", "staging" and "production".
+
+You will need to enter your Cognito/Sinopia Editor username (usually SUNETID@stanford.edu) and password (note: it may not appear that there is a prompt after you execute the bin command).
 
 **NOTE**: If you provide none of the above environment variables, `bin/authenticate` will default to the Sinopia development instance of Cognito and its sole user pool.
 

--- a/__tests__/endpoints/groups.test.js
+++ b/__tests__/endpoints/groups.test.js
@@ -1,17 +1,7 @@
-import connect from 'mongo.js'
 import request from 'supertest'
 import app from 'app.js'
 
-jest.mock('mongo.js')
-
 describe('GET /groups', () => {
-  const mockDistinct = jest.fn().mockResolvedValue([
-'stanford',
-'pcc'
-])
-  const mockCollection = jest.fn().mockReturnValue({distinct: mockDistinct})
-  const mockDb = {collection: mockCollection}
-  connect.mockReturnValue(mockDb)
 
   it('returns the resource', async () => {
 
@@ -19,10 +9,11 @@ describe('GET /groups', () => {
       .get('/groups')
       .set('Accept', 'application/json')
     expect(res.statusCode).toEqual(200)
-    expect(res.body).toEqual({data: [
-{id: 'stanford'},
-{id: 'pcc'}
-]})
-    expect(mockDistinct.mock.calls[0][0]).toBe('group')
-  })
+    expect(res.type).toEqual('application/json')
+    expect(res.body.data).toEqual(expect.arrayContaining([
+      {id: "stanford", "label": "Stanford University"},
+      {id: "cornell", "label": "Cornell University"}
+   ]))
+   expect(res.body.data.length).toBeGreaterThanOrEqual(25)
+})
 })

--- a/openapi.yml
+++ b/openapi.yml
@@ -437,7 +437,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/Groups'
   /user/{userId}:
     get:
       summary: Return data for a user
@@ -455,7 +455,7 @@ paths:
           content:
             application/json:
               schema:
-                    $ref: '#/components/schemas/Errors'
+                $ref: '#/components/schemas/Errors'
       parameters:
         - name: userId
           in: path
@@ -585,7 +585,7 @@ components:
         properties:
           title:
             type: string
-          details: 
+          details:
             type: string
           status:
             type: string
@@ -713,6 +713,23 @@ components:
       required:
         - data
         - id
+    Groups:
+      description: Response containing list of groups
+      type: object
+      properties:
+        data:
+          description: The list of groups
+          type: array
+          items:
+            description: A single group
+            type: object
+            properties:
+              id:
+                description: The unique ID of the group
+                type: string
+              label:
+                description: The name of the group shown to the user
+                type: string
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/endpoints/groups.js
+++ b/src/endpoints/groups.js
@@ -2,14 +2,39 @@ import express from 'express'
 
 const groupsRouter = express.Router()
 
-groupsRouter.get('/', (req, res, next) => {
-  req.db.collection('resources').distinct('group')
-    .then((groups) => {
-      res.send({
-        data: groups.map((group) => ({id: group}))
-      })
-    })
-    .catch(next)
+groupsRouter.get('/', (req, res) => {
+  console.log(`Received get to ${req}`)
+
+  // For now, hardcode the groups response: see https://github.com/ld4p/sinopia_api/issues/143
+  // Later, this will be dynamically fetched from Cognito and then used by the editor
+  const groups = [
+      {id: "alberta", label: "University of Alberta"},
+      {id: "boulder", label: "University of Colorado, Boulder"},
+      {id: "chicago", label: "University of Chicago"},
+      {id: "cornell", label: "Cornell University"},
+      {id: "dlc", label: "Library of Congress"},
+      {id: "duke", label: "Duke University"},
+      {id: "frick", label: "Frick Art Reference Library"},
+      {id: "harvard", label: "Harvard University"},
+      {id: "hrc", label: "University of Texas, Austin, Harry Ransom Center"},
+      {id: "ld4p", label: "LD4P"},
+      {id: "michigan", label: "University of Michigan"},
+      {id: "minnesota", label: "University of Minnesota"},
+      {id: "mla", label: "Music Library Association"},
+      {id: "nlm", label: "National Library of Medicine"},
+      {id: "northwestern", label: "Northwestern University"},
+      {id: "other", label: "Other"},
+      {id: "pcc", label: "PCC"},
+      {id: "penn", label: " 'University of Pennsylvania"},
+      {id: "princeton", label: "Princeton University"},
+      {id: "stanford", label: "Stanford University"},
+      {id: "tamu", label: " 'Texas A&M University"},
+      {id: "ucdavis", label: "University of California, Davis"},
+      {id: "ucsd", label: "University of California, San Diego"},
+      {id: "washington", label: "University of Washington"},
+      {id: "yale", label: "Yale University"}
+    ]
+  res.json({data: groups})
 })
 
 export default groupsRouter


### PR DESCRIPTION
## Why was this change made?

Fixes #143 

- hardcode list of groups (currently matches sinopia editor hardcoded groups)
- return this list in a new json structure on the `/groups` endpoint
- document response object in openapi.yml
- updates to the README with additional details about fetching JWT tokens from Cognito.

Note, this changes the response structure, so any consumers of this API will need to change after this is merged.

New response looks like this:

```
{"data":
  [
    {"id":"alberta","label":"University of Alberta"},
    {"id":"boulder","label":"University of Colorado, Boulder"},
    {"id":"chicago","label":"University of Chicago"},.... etc
  ]
}
```

## How was this change tested?



## Which documentation and/or configurations were updated?




