### PR TITLE
Fixed bad request error

### DIFF
--- a/src/endpoints/resources.js
+++ b/src/endpoints/resources.js
@@ -271,11 +271,9 @@ const queryFor = (qs) => {
 
 const parseDate = (dateString) => {
   const date = new Date(dateString)
-  if (isNaN(date)) {
-    throw createError(400, "Bad Request", {
-      details: `Invalid date-time: ${dateString}`,
-    })
-  }
+  if (isNaN(date))
+    throw new createError.BadRequest(`Invalid date-time: ${dateString}`)
+
   return date
 }
 


### PR DESCRIPTION
## Why was this change made?
This was throwing the error incorrectly.


## How was this change tested?
A bad date should be caught by openapi. This is backup, so it is not tested.



## Which documentation and/or configurations were updated?




