### PR TITLE
Increases the number of groups from Cognito.

### DIFF
--- a/__tests__/aws.test.js
+++ b/__tests__/aws.test.js
@@ -203,7 +203,10 @@ describe("listGroups", () => {
   describe("getting successful", () => {
     it("resolves record", async () => {
       mockListGroups.mockImplementation((params, callback) => {
-        expect(params).toEqual({ UserPoolId: "us-west-2_CGd9Wq136" })
+        expect(params).toEqual({
+          UserPoolId: "us-west-2_CGd9Wq136",
+          Limit: 250,
+        })
         callback(null, {
           Groups: [
             { GroupName: "stanford", Description: "Stanford University" },

--- a/src/aws.js
+++ b/src/aws.js
@@ -99,7 +99,7 @@ const getError = (resourceId, username, timestamp) => {
 export const listGroups = () => {
   const cognito = new AWS.CognitoIdentityServiceProvider()
   return new Promise((resolve, reject) => {
-    cognito.listGroups({ UserPoolId: userPoolId }, (err, data) => {
+    cognito.listGroups({ UserPoolId: userPoolId, Limit: 250 }, (err, data) => {
       if (err) reject(err)
       else
         resolve(


### PR DESCRIPTION
closes https://github.com/LD4P/sinopia_editor/issues/3048

## Why was this change made?
Not all of the groups were being retrieved from Cognito and this beats paging.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?




