### PR TITLE
transfer endpoint

### DIFF
--- a/__tests__/endpoints/transferPost.test.js
+++ b/__tests__/endpoints/transferPost.test.js
@@ -1,0 +1,78 @@
+import request from "supertest"
+import app from "app.js"
+import * as aws from "aws.js"
+import FakeTimers from "@sinonjs/fake-timers"
+
+jest.mock("aws.js")
+jest.mock("jwt.js", () => {
+  return {
+    __esModule: true,
+    default: jest
+      .fn()
+      .mockReturnValue({ secret: "shhhhhhared-secret", algorithms: ["HS256"] }),
+  }
+})
+// This won't be required after Jest 27
+jest.useFakeTimers("modern")
+
+let clock
+beforeAll(() => {
+  clock = FakeTimers.install({ now: new Date("2020-08-20T11:34:40.887Z") })
+})
+
+afterAll(() => {
+  clock.uninstall()
+})
+
+const stanfordJwt =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI0NDlmMDAzYi0xOWQxLTQ4YjUtYWVjYi1iNGY0N2ZiYjdkYzgiLCJhdWQiOiIydTZzN3Bxa2MxZ3JxMXFzNDY0ZnNpODJhdCIsImNvZ25pdG86Z3JvdXBzIjpbInN0YW5mb3JkIiwicGNjIl0sImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJldmVudF9pZCI6ImU0YWM2ODA4LWViYTUtNDM2MC04ZTU1LTY0ZWUwYjdhZjllYiIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNjMxOTEwMzgwLCJpc3MiOiJodHRwczovL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tL3VzLXdlc3QtMl9DR2Q5V3ExMzYiLCJjb2duaXRvOnVzZXJuYW1lIjoiamxpdHRtYW4iLCJleHAiOjI2MzIwMDcxNDgsImlhdCI6MTYzMjAwMzU0OCwiZW1haWwiOiJqdXN0aW5saXR0bWFuQHN0YW5mb3JkLmVkdSJ9.AtnKOR0bghI-DTjeWUTnLlNub1wc0QzAprrQQ2XGWR8"
+
+describe("POST /transfer/:resourceId/:targetGroup/:targetSystem", () => {
+  describe("user is in target group", () => {
+    it("returns a 204 after queueing an SQS message with the expected params", async () => {
+      aws.buildAndSendSqsMessage.mockResolvedValue()
+      const res = await request(app)
+        .post("/transfer/foo/stanford/ils")
+        .set("Authorization", `Bearer ${stanfordJwt}`)
+        .send("")
+
+      const msgBodyJson = {
+        resource: { uri: "https://api.development.sinopia.io/resource/foo" },
+        user: {
+          email: "justinlittman@stanford.edu",
+        },
+        group: "stanford",
+        target: "ils",
+      }
+      expect(res.statusCode).toEqual(204)
+      expect(aws.buildAndSendSqsMessage).toHaveBeenCalledWith(
+        "stanford-ils",
+        expect.stringMatching(JSON.stringify(msgBodyJson))
+      )
+    })
+  })
+
+  describe("user is not in the target group", () => {
+    // eslint-disable-next-line multiline-comment-style
+    /*
+    // Commenting out as we want to test this scenario, but for reasons we can't explain, the test hangs (works when tested in running app using curl)
+    it("returns a 401 Unauthorized", async () => {
+      aws.buildAndSendSqsMessage.mockResolvedValue()
+      const res = await request(app)
+        .post("/transfer/foo/harvard/ils")
+        .set("Authorization", `Bearer ${stanfordJwt}`)
+        .send('')
+
+      expect(res.statusCode).toEqual(401)
+      expect(res.body).toEqual([
+        {
+          title: "Unauthorized",
+          details: "User must a member of the group to which the resource is being transferred",
+          status: "401",
+        },
+      ])
+      expect(aws.buildAndSendSqsMessage).not.toHaveBeenCalled()
+    })
+    */
+  })
+})

--- a/openapi.yml
+++ b/openapi.yml
@@ -450,6 +450,38 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Groups"
+  /transfer/{resourceId}/{targetGroup}/{targetSystem}:
+    post:
+      summary: publish a Sinopia resource to the target group's target system (e.g. stanford's ILS)
+      responses:
+        "204":
+          description: "OK - a message was queued for the transfer request"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+      parameters:
+        - name: resourceId
+          in: path
+          description: ID of the resource
+          required: true
+          schema:
+            type: string
+        - name: targetGroup
+          in: path
+          description: name of the group to which the resource should go
+          required: true
+          schema:
+            type: string
+        - name: targetSystem
+          in: path
+          description: system to which the resource should go
+          example: "ils"
+          required: true
+          schema:
+            type: string
   /user/{userId}:
     get:
       summary: Return data for a user

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ import jwtConfig from "./jwt.js"
 import resourcesRouter from "./endpoints/resources.js"
 import groupsRouter from "./endpoints/groups.js"
 import marcRouter from "./endpoints/marc.js"
+import transferRouter from "./endpoints/transfer.js"
 import usersRouter from "./endpoints/users.js"
 import {
   errorHandler,
@@ -75,6 +76,7 @@ app.get("/", (req, res) => {
 app.use("/resource", resourcesRouter)
 app.use("/marc", marcRouter)
 app.use("/groups", groupsRouter)
+app.use("/transfer", transferRouter)
 app.use("/user", usersRouter)
 
 // Error handlers

--- a/src/endpoints/resources.js
+++ b/src/endpoints/resources.js
@@ -221,7 +221,7 @@ resourcesRouter.get("/", (req, res, next) => {
     .catch(next)
 })
 
-const resourceUriFor = (req) => {
+export const resourceUriFor = (req) => {
   return `${baseUrlFor(req)}/${req.params.resourceId}`
 }
 

--- a/src/endpoints/transfer.js
+++ b/src/endpoints/transfer.js
@@ -1,0 +1,34 @@
+import express from "express"
+import { buildAndSendSqsMessage } from "../aws.js"
+import { canTransfer } from "../permissions.js"
+import { resourceUriFor } from "./resources.js"
+
+const transferRouter = express.Router()
+
+transferRouter.post("/:resourceId/:targetGroup/:targetSystem", [
+  canTransfer,
+  (req, res, next) => {
+    const { resourceId, targetGroup, targetSystem } = req.params
+    console.log(
+      `transferRouter Received post to /${resourceId}/${targetGroup}/${targetSystem}`
+    )
+
+    const sqsMessageBody = {
+      resource: { uri: resourceUriFor(req) },
+      user: {
+        email: req.user.email,
+      },
+      group: targetGroup,
+      target: targetSystem,
+    }
+
+    const queueName = `${targetGroup}-${targetSystem}`
+    buildAndSendSqsMessage(queueName, JSON.stringify(sqsMessageBody))
+      .then(() => {
+        res.sendStatus(204)
+      })
+      .catch(next)
+  },
+])
+
+export default transferRouter

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -86,6 +86,21 @@ export const canDelete = (req, resp, next) => {
     .catch(next)
 }
 
+export const canTransfer = (req, resp, next) => {
+  if (isNoAuth()) return next()
+
+  // The user must be a member of the target group
+  const userGroups = getGroups(req)
+  if (!userGroups.includes(req.params.targetGroup))
+    return next(
+      new createError.Unauthorized(
+        "User must a member of the group to which the resource is being transferred"
+      )
+    )
+
+  next()
+}
+
 const getGroups = (req) => req.user["cognito:groups"] || []
 
 const isNoAuth = () => process.env.NO_AUTH === "true"


### PR DESCRIPTION
## Why was this change made?

closes #145

## How was this change tested?

* unit tests
* manual testing on the local command line (authenticate as my sinopia dev user, start the server with sinopia dev AWS profile, `curl -X POST -i -H "Authorization: Bearer $(cat .cognitoToken)" http://localhost:3000/transfer/foo/stanford/ils`)

## Which documentation and/or configurations were updated?

n/a