### PR TITLE
Switch commandline auth to store id token.

### DIFF
--- a/src/cli/authenticateClient.js
+++ b/src/cli/authenticateClient.js
@@ -35,7 +35,7 @@ export default class AuthenticateClient {
   }
 
   async cognitoTokenToFile() {
-    await this.accessTokenPromise()
+    await this.idTokenPromise()
       .then((jwt) => {
         try {
           fs.writeFileSync(this.cognitoTokenFile, jwt)
@@ -45,7 +45,7 @@ export default class AuthenticateClient {
       })
       .catch((err) => {
         console.error(
-          `ERROR: problem getting cognito accessToken: ${util.inspect(err)}`
+          `ERROR: problem getting cognito idToken: ${util.inspect(err)}`
         )
       })
   }
@@ -109,16 +109,16 @@ export default class AuthenticateClient {
     return subAttribute.Value
   }
 
-  accessTokenPromise() {
+  idTokenPromise() {
     return new Promise((resolve, reject) => {
       this.cognitoUser().authenticateUser(this.authenticationDetails(), {
         onSuccess: (result) => {
-          const jwt = result.getAccessToken().getJwtToken()
+          const jwt = result.getIdToken().getJwtToken()
           if (jwt) resolve(jwt)
           else
             reject(
               new Error(
-                `ERROR: retrieved null cognito access token for ${this.username}`
+                `ERROR: retrieved null cognito id token for ${this.username}`
               )
             )
         },


### PR DESCRIPTION
## Why was this change made?
The API expects an id token, not an access token.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?




