### PR TITLE
Template ID, not Template Id

### DIFF
--- a/setup/rt_resource_property_attrs_doc.json
+++ b/setup/rt_resource_property_attrs_doc.json
@@ -8,17 +8,15 @@
   "data": [
     {
       "@id": "_:b2",
-      "@type": [
-        "http://sinopia.io/vocabulary/PropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
       "http://www!w3!org/2000/01/rdf-schema#label": [
         {
-          "@value": "Resource template ids"
+          "@value": "Resource Template IDs"
         }
       ],
       "http://sinopia!io/vocabulary/hasRemark": [
         {
-          "@value": "Resource template ids, e.g., ld4p:RT:bf2:Title:AbbrTitle."
+          "@value": "Resource Template IDs, e.g., ld4p:RT:bf2:Title:AbbrTitle."
         }
       ],
       "http://sinopia!io/vocabulary/hasPropertyUri": [
@@ -47,9 +45,7 @@
     },
     {
       "@id": "_:b3",
-      "@type": [
-        "http://sinopia.io/vocabulary/LookupPropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/LookupPropertyTemplate"],
       "http://sinopia!io/vocabulary/hasAuthority": [
         {
           "@id": "urn:ld4p:sinopia:resourceTemplate"
@@ -63,9 +59,7 @@
           "@value": "sinopia:template:resource"
         }
       ],
-      "@type": [
-        "http://sinopia.io/vocabulary/ResourceTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/ResourceTemplate"],
       "http://sinopia!io/vocabulary/hasResourceId": [
         {
           "@value": "sinopia:template:property:resource"

--- a/setup/rt_resource_template_doc.json
+++ b/setup/rt_resource_template_doc.json
@@ -8,9 +8,7 @@
   "data": [
     {
       "@id": "_:b11",
-      "@type": [
-        "http://sinopia.io/vocabulary/PropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
       "http://www!w3!org/2000/01/rdf-schema#label": [
         {
           "@value": "Remark"
@@ -34,9 +32,7 @@
     },
     {
       "@id": "_:b13",
-      "@type": [
-        "http://sinopia.io/vocabulary/PropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
       "http://www!w3!org/2000/01/rdf-schema#label": [
         {
           "@value": "Date"
@@ -60,9 +56,7 @@
     },
     {
       "@id": "_:b14",
-      "@type": [
-        "http://sinopia.io/vocabulary/PropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
       "http://www!w3!org/2000/01/rdf-schema#label": [
         {
           "@value": "Property templates"
@@ -99,9 +93,7 @@
     },
     {
       "@id": "_:b15",
-      "@type": [
-        "http://sinopia.io/vocabulary/ResourcePropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/ResourcePropertyTemplate"],
       "http://sinopia!io/vocabulary/hasResourceTemplateId": [
         {
           "@id": "sinopia:template:property"
@@ -110,17 +102,15 @@
     },
     {
       "@id": "_:b3",
-      "@type": [
-        "http://sinopia.io/vocabulary/PropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
       "http://www!w3!org/2000/01/rdf-schema#label": [
         {
-          "@value": "Template Id"
+          "@value": "Template ID"
         }
       ],
       "http://sinopia!io/vocabulary/hasRemark": [
         {
-          "@value": "The resource's Template Id, e.g., ld4p:RT:bf2:Title:AbbrTitle."
+          "@value": "The resource's Template ID, e.g., ld4p:RT:bf2:Title:AbbrTitle."
         }
       ],
       "http://sinopia!io/vocabulary/hasPropertyUri": [
@@ -141,9 +131,7 @@
     },
     {
       "@id": "_:b5",
-      "@type": [
-        "http://sinopia.io/vocabulary/PropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
       "http://www!w3!org/2000/01/rdf-schema#label": [
         {
           "@value": "Class"
@@ -172,9 +160,7 @@
     },
     {
       "@id": "_:b7",
-      "@type": [
-        "http://sinopia.io/vocabulary/PropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
       "http://www!w3!org/2000/01/rdf-schema#label": [
         {
           "@value": "Template Label"
@@ -203,9 +189,7 @@
     },
     {
       "@id": "_:b9",
-      "@type": [
-        "http://sinopia.io/vocabulary/PropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
       "http://www!w3!org/2000/01/rdf-schema#label": [
         {
           "@value": "Author"
@@ -229,9 +213,7 @@
     },
     {
       "@id": "_:b16",
-      "@type": [
-        "http://sinopia.io/vocabulary/PropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
       "http://www!w3!org/2000/01/rdf-schema#label": [
         {
           "@value": "Resource attributes"
@@ -265,9 +247,7 @@
     },
     {
       "@id": "_:b17",
-      "@type": [
-        "http://sinopia.io/vocabulary/LookupPropertyTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/LookupPropertyTemplate"],
       "http://sinopia!io/vocabulary/hasAuthority": [
         {
           "@id": "file:/resourceAttribute.json"
@@ -281,9 +261,7 @@
           "@value": "sinopia:template:resource"
         }
       ],
-      "@type": [
-        "http://sinopia.io/vocabulary/ResourceTemplate"
-      ],
+      "@type": ["http://sinopia.io/vocabulary/ResourceTemplate"],
       "http://sinopia!io/vocabulary/hasResourceId": [
         {
           "@value": "sinopia:template:resource"


### PR DESCRIPTION
## Why was this change made?

Fixes #195, which is really about getting "Template ID" in the uber template (?).  

I looked for "Template Id" and for "Id" in sinopia_editor and didn't find it, so I *think* this is how to fix it, based on these hints in ticket #2414

![image](https://user-images.githubusercontent.com/96775/136289923-af3f8144-7a5e-4f27-be59-5dbd36e00168.png)

![image](https://user-images.githubusercontent.com/96775/136290152-930cfe40-72bd-4cce-b04f-d0e4a0733900.png)


## How was this change tested?

er ...   Need help getting the right sinopia_api deployed with sinopia_editor to be able to tell (?)

## Which documentation and/or configurations were updated?




