### PR TITLE
update README linting to include prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,27 @@ If you are working on the MARC endpoints, supply the AWS credentials:
 ## Developers
 
 ### Linter for JavaScript
-To run eslint:
+
+There are two linters/formatters used in this project: eslint and prettier.
+They can be run together or individually.
+
+To run both:
+`npm run lint`
+
+To auto-fix errors in both (where possible):
+`npm run fix`
+
+To run just eslint:
 `npm run eslint`
 
-To automatically fix problems (where possible):
+To automatically fix just eslint problems (where possible):
 `npm run eslint-fix`
+
+To run just prettier:
+`npm run pretty`
+
+To automatically fix just prettier problems (where possible):
+`npm run pretty-fix`
 
 ### Monitoring Mongo
 Mongo Express is available for monitoring local Mongo at http://localhost:8082.


### PR DESCRIPTION
## Why was this change made?

linting instructions were no longer accurate.

## How was this change tested?



## Which documentation and/or configurations were updated?




