### PR TITLE
change 409 response error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ To run just prettier:
 To automatically fix just prettier problems (where possible):
 `npm run pretty-fix`
 
+### Unit, feature, and integration tests
+
+Tests are written with jest.
+
+To run all of the tests:
+`npm test`
+
+To run a single test file (and see console messages):
+`npx jest __tests__/endpoints/resourcePost.test.js`
+
+To run a single test (and see console messages):
+`npx jest __tests__/endpoints/resourcePost.test.js -t "returns 409 if resource is not unique"`
+
+Or temporarily change the test description from `it("does something")` to `it.only("does something")` and run the single test file with `npx`.
+
 ### Monitoring Mongo
 Mongo Express is available for monitoring local Mongo at http://localhost:8082.
 

--- a/__tests__/endpoints/resourcePost.test.js
+++ b/__tests__/endpoints/resourcePost.test.js
@@ -134,7 +134,7 @@ describe("POST /resource/:resourceId", () => {
     expect(res.body).toEqual([
       {
         title: "Conflict",
-        details: "Id is not unique",
+        details: "ID is already in use. Please choose a unique ID.",
         status: "409",
       },
     ])

--- a/__tests__/endpoints/userPost.test.js
+++ b/__tests__/endpoints/userPost.test.js
@@ -67,7 +67,7 @@ describe("POST /user/:userId", () => {
     expect(res.body).toEqual([
       {
         title: "Conflict",
-        details: "Id is not unique",
+        details: "ID is already in use. Please choose a unique ID.",
         status: "409",
       },
     ])

--- a/src/error.js
+++ b/src/error.js
@@ -35,7 +35,11 @@ export const jwtErrorAdapter = (err, req, res, next) => {
 export const mongoErrorAdapter = (err, req, res, next) => {
   // Mongo error for dupe key
   if (err.code === 11000) {
-    return next(new createError.Conflict("Id is not unique"))
+    return next(
+      new createError.Conflict(
+        "ID is already in use. Please choose a unique ID."
+      )
+    )
   }
   return next(err)
 }


### PR DESCRIPTION
~~HOLD for signoff from @michelleif for delivering something different than what was requested in LD4P/sinopia_editor#2457~~

## Why was this change made?

Clearer error message for Sinopia Editor users.

Part of LD4P/sinopia_editor#2457

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

README - added instructions for developer testing of code

