### PR TITLE
filter out admin group from groups API endpoint

### DIFF
--- a/__tests__/endpoints/groups.test.js
+++ b/__tests__/endpoints/groups.test.js
@@ -8,6 +8,12 @@ describe("GET /groups", () => {
   const groups = [
     { id: "stanford", label: "Stanford University" },
     { id: "cornell", label: "Cornell University" },
+    { id: "admin", label: "Admin group for middleware user" },
+  ]
+
+  const filteredGroups = [
+    { id: "stanford", label: "Stanford University" },
+    { id: "cornell", label: "Cornell University" },
   ]
 
   aws.listGroups.mockResolvedValue(groups)
@@ -18,6 +24,6 @@ describe("GET /groups", () => {
       .set("Accept", "application/json")
     expect(res.statusCode).toEqual(200)
     expect(res.type).toEqual("application/json")
-    expect(res.body.data).toEqual(expect.arrayContaining(groups))
+    expect(res.body.data).toEqual(filteredGroups)
   })
 })

--- a/src/endpoints/groups.js
+++ b/src/endpoints/groups.js
@@ -4,7 +4,9 @@ import { listGroups } from "../aws.js"
 const groupsRouter = express.Router()
 
 groupsRouter.get("/", (req, res, next) => {
+  // Filter out admin group
   listGroups()
+    .then((groups) => groups.filter((group) => group.id !== "admin"))
     .then((groups) => res.json({ data: groups }))
     .catch(next)
 })


### PR DESCRIPTION
## Why was this change made?

Fixes #203 - filter out admin group from groups API endpoint

## How was this change tested?

Updated test


## Which documentation and/or configurations were updated?




