### PR TITLE
rename references to relationships

### DIFF
--- a/__tests__/endpoints/resourceGet.test.js
+++ b/__tests__/endpoints/resourceGet.test.js
@@ -210,9 +210,9 @@ describe("GET /resource/:resourceId/version/:timestamp", () => {
   })
 })
 
-// GET the references for a resource
-describe("GET /resource/:resourceId/references", () => {
-  it("returns the references", async () => {
+// GET the relationships for a resource
+describe("GET /resource/:resourceId/relationships", () => {
+  it("returns the relationships", async () => {
     const resourceResult = {
       id: "6852a770-2961-4836-a833-0b21a9b68041",
       uri: "http://localhost:3000/resource/6852a770-2961-4836-a833-0b21a9b68041",
@@ -230,7 +230,7 @@ describe("GET /resource/:resourceId/references", () => {
         "http://localhost:3000/resource/g636dee4-65e3-457f-9215-740531104684",
       ],
     }
-    // Note that the references don't make BF sense, but are testing for completeness.
+    // Note that the relationships don't make BF sense, but are testing for completeness.
     const mockFindOne = jest.fn().mockResolvedValue(resourceResult)
     const mockFind = jest.fn().mockResolvedValue(resourceRefResults)
     const mockCollection = (collectionName) => {
@@ -242,7 +242,7 @@ describe("GET /resource/:resourceId/references", () => {
     connect.mockImplementation(mockConnect(mockDb))
 
     const res = await request(app)
-      .get("/resource/6852a770-2961-4836-a833-0b21a9b68041/references")
+      .get("/resource/6852a770-2961-4836-a833-0b21a9b68041/relationships")
       .set("Accept", "application/json")
     expect(res.statusCode).toEqual(200)
     expect(res.body).toEqual(resourceRefsResp)
@@ -259,7 +259,7 @@ describe("GET /resource/:resourceId/references", () => {
     connect.mockImplementation(mockConnect(mockDb))
 
     const res = await request(app)
-      .get("/resource/6852a770-2961-4836-a833-0b21a9b68041/references")
+      .get("/resource/6852a770-2961-4836-a833-0b21a9b68041/relationships")
       .set("Accept", "application/json")
     expect(res.statusCode).toEqual(404)
   })

--- a/openapi.yml
+++ b/openapi.yml
@@ -296,9 +296,9 @@ paths:
           required: true
           schema:
             type: string
-  /resource/{resourceId}/references:
+  /resource/{resourceId}/relationships:
     get:
-      summary: Returns information about references between this resource and other resources
+      summary: Returns information about relationships between this resource and other resources
       tags:
         - resources
       responses:
@@ -307,7 +307,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/References"
+                $ref: "#/components/schemas/Relationships"
       parameters:
         - name: resourceId
           in: path
@@ -656,67 +656,67 @@ components:
         required:
           - title
           - status
-    References:
-      description: Response describing the references between this resource and other resources.
+    Relationships:
+      description: Response describing the relationships between this resource and other resources.
       type: object
       properties:
         bfAdminMetadataRefs:
-          description: References to Bibframe AdminMetadata contained within this record.
+          description: Relationships to Bibframe AdminMetadata contained within this record.
           type: array
           items:
             type: string
         bfItemRefs:
-          description: References to Bibframe Items contained within this record.
+          description: Relationships to Bibframe Items contained within this record.
           type: array
           items:
             type: string
         bfInstanceRefs:
-          description: References to Bibframe Instances contained within this record.
+          description: Relationships to Bibframe Instances contained within this record.
           type: array
           items:
             type: string
         bfWorkRefs:
-          description: References to Bibframe Instances contained within this record.
+          description: Relationships to Bibframe Instances contained within this record.
           type: array
           items:
             type: string
         bfAdminMetadataInferredRefs:
-          description: References to Bibframe AdminMetadata inferred from other resources.
+          description: Relationships to Bibframe AdminMetadata inferred from other resources.
           type: array
           items:
             type: string
         bfItemInferredRefs:
-          description: References to Bibframe Items inferred from other resources.
+          description: Relationships to Bibframe Items inferred from other resources.
           type: array
           items:
             type: string
         bfInstanceInferredRefs:
-          description: References to Bibframe Instances inferred from other resources.
+          description: Relationships to Bibframe Instances inferred from other resources.
           type: array
           items:
             type: string
         bfWorkInferredRefs:
-          description: References to Bibframe Instances inferred from other resources.
+          description: Relationships to Bibframe Instances inferred from other resources.
           type: array
           items:
             type: string
         bfAdminMetadataAllRefs:
-          description: References to Bibframe AdminMetadata contained within this record and inferred from other resources.
+          description: Relationships to Bibframe AdminMetadata contained within this record and inferred from other resources.
           type: array
           items:
             type: string
         bfItemAllRefs:
-          description: References to Bibframe Items contained within this record and inferred from other resources.
+          description: Relationships to Bibframe Items contained within this record and inferred from other resources.
           type: array
           items:
             type: string
         bfInstanceAllRefs:
-          description: References to Bibframe Instances contained within this record and inferred from other resources.
+          description: Relationships to Bibframe Instances contained within this record and inferred from other resources.
           type: array
           items:
             type: string
         bfWorkAllRefs:
-          description: References to Bibframe Instances contained within this record and inferred from other resources.
+          description: Relationships to Bibframe Instances contained within this record and inferred from other resources.
           type: array
           items:
             type: string
@@ -748,22 +748,22 @@ components:
           items:
             type: object
         bfAdminMetadataRefs:
-          description: References to Bibframe AdminMetadata contained within this record.
+          description: Relationships to Bibframe AdminMetadata contained within this record.
           type: array
           items:
             type: string
         bfItemRefs:
-          description: References to Bibframe Items contained within this record.
+          description: Relationships to Bibframe Items contained within this record.
           type: array
           items:
             type: string
         bfInstanceRefs:
-          description: References to Bibframe Instances contained within this record.
+          description: Relationships to Bibframe Instances contained within this record.
           type: array
           items:
             type: string
         bfWorkRefs:
-          description: References to Bibframe Instances contained within this record.
+          description: Relationships to Bibframe Instances contained within this record.
           type: array
           items:
             type: string

--- a/src/endpoints/resources.js
+++ b/src/endpoints/resources.js
@@ -149,7 +149,7 @@ resourcesRouter.delete("/:resourceId", [
   },
 ])
 
-resourcesRouter.get("/:resourceId/references", (req, res, next) => {
+resourcesRouter.get("/:resourceId/relationships", (req, res, next) => {
   const projection = {
     id: 1,
     bfAdminMetadataRefs: 1,


### PR DESCRIPTION
## Why was this change made?

Fixes #212 - rename `references` endpoint in the `resources` section to `relationships`

Note: no other projects were changed, so any consumers of this endpoint need to be informed.

## How was this change tested?

Updated existing tests

## Which documentation and/or configurations were updated?




