### PR TITLE
[HOLD] rt_literal_property_attrs_doc.json: add hasValidationRegex

### DIFF
--- a/setup/rt_literal_property_attrs_doc.json
+++ b/setup/rt_literal_property_attrs_doc.json
@@ -38,6 +38,32 @@
       ]
     },
     {
+      "@id": "_:b3",
+      "@type": [
+        "http://sinopia.io/vocabulary/PropertyTemplate"
+      ],
+      "http://www!w3!org/2000/01/rdf-schema#label": [
+        {
+          "@value": "Validation Regular Expression"
+        }
+      ],
+      "http://sinopia!io/vocabulary/hasRemark": [
+        {
+          "@value": "Regular Expression to validate the literal."
+        }
+      ],
+      "http://sinopia!io/vocabulary/hasPropertyUri": [
+        {
+          "@id": "http://sinopia.io/vocabulary/hasValidationRegex"
+        }
+      ],
+      "http://sinopia!io/vocabulary/hasPropertyType": [
+        {
+          "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+        }
+      ]
+    },
+    {
       "@id": "http://localhost:3000/resource/sinopia:template:property:literal",
       "http://sinopia!io/vocabulary/hasResourceTemplate": [
         {
@@ -72,6 +98,9 @@
           "@list": [
             {
               "@id": "_:b2"
+            },
+            {
+              "@id": "_:b3"
             }
           ]
         }


### PR DESCRIPTION
### HOLD until JLitt is done with refactor from #3266
(or whenever @justinlittman wants to merge it)

(or redo in sinopia_editor after LD4P/sinopia_editor/pull/3279 is merged)

## Why was this change made?

Part of LD4P/sinopia_editor/issues/2907
(detailed steps to complete here:  https://github.com/LD4P/sinopia_editor/issues/2907#issuecomment-954262890)

NOTE:  @justinlittman is actively changing where the "base templates" (the json that tells the editor what components to display for creating/editing resource templates) live per #3266, so this PR should not be merged until he is ready.

### After

![image](https://user-images.githubusercontent.com/96775/139345434-3aaeadf3-944a-4f60-9130-1f4224940836.png)

## How was this change tested?

running with this base template loaded locally on my laptop

## Which documentation and/or configurations were updated?




