### PR TITLE
[HOLD] rt_literal_property_attrs_doc.json: add hasValidationDataType

### DIFF
--- a/setup/rt_literal_property_attrs_doc.json
+++ b/setup/rt_literal_property_attrs_doc.json
@@ -38,6 +38,48 @@
       ]
     },
     {
+      "@id": "_:b4",
+      "@type": [
+        "http://sinopia.io/vocabulary/PropertyTemplate"
+      ],
+      "http://www!w3!org/2000/01/rdf-schema#label": [
+        {
+          "@value": "Validation Data Type"
+        }
+      ],
+      "http://sinopia!io/vocabulary/hasRemark": [
+        {
+          "@value": "Data Type to validate the literal, e.g. integer or dateTime."
+        }
+      ],
+      "http://sinopia!io/vocabulary/hasPropertyUri": [
+        {
+          "@id": "http://sinopia.io/vocabulary/hasValidationDataType"
+        }
+      ],
+      "http://sinopia!io/vocabulary/hasPropertyType": [
+        {
+          "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+        }
+      ],
+      "http://sinopia!io/vocabulary/hasLookupAttributes": [
+        {
+          "@id": "_:b5"
+        }
+      ]
+    },
+    {
+      "@id": "_:b5",
+      "@type": [
+        "http://sinopia.io/vocabulary/LookupPropertyTemplate"
+      ],
+      "http://sinopia!io/vocabulary/hasAuthority": [
+        {
+          "@id": "file:/literalDataType.json"
+        }
+      ]
+    },
+    {
       "@id": "http://localhost:3000/resource/sinopia:template:property:literal",
       "http://sinopia!io/vocabulary/hasResourceTemplate": [
         {
@@ -72,6 +114,9 @@
           "@list": [
             {
               "@id": "_:b2"
+            },
+            {
+              "@id": "_:b4"
             }
           ]
         }


### PR DESCRIPTION
### HOLD until JLitt is done with refactor from LD4P/sinpoia_editor#3266
(or whenever @justinlittman wants to merge it)

(or redo in sinopia_editor after LD4P/sinopia_editor/pull/3279 and LD4P/sinopia_editor/pull/3278 are merged)

### HOLD until LD4P/sinopia_editor#2889 is merged
(or whenever @justinlittman wants to merge it)

## Why was this change made?

Part of LD4P/sinopia_editor/issues/2889
(detailed steps to complete here:  https://github.com/LD4P/sinopia_editor/issues/2889#issuecomment-954261209)

Utilize new Validation Data Type list as a list type for literal property.

NOTE:  @justinlittman is actively changing where the "base templates" (the json that tells the editor what components to display for creating/editing resource templates) live per LD4P/sinopia_editor#3266, so this PR should not be merged until he is ready.

### After

![image](https://user-images.githubusercontent.com/96775/139501641-1d1a3e3a-3b4a-4965-a2a8-9612dae13b56.png)

![image](https://user-images.githubusercontent.com/96775/139500560-f1990e32-57ed-4aa4-9a4b-200cf7f3d1ed.png)

## How was this change tested?

running with this base template loaded locally on my laptop

## Which documentation and/or configurations were updated?

