### PR TITLE
add a user count metric endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ If you are working on the MARC endpoints, supply the AWS credentials:
 
 ## Developers
 
+### Frameworks
+
+Sinopia API uses Monk as the Mongo framework and Express as the HTTP framework:
+
+- https://automattic.github.io/monk/
+- https://expressjs.com/
+
 ### Linter for JavaScript
 
 There are two linters/formatters used in this project: eslint and prettier.
@@ -82,9 +89,15 @@ Or temporarily change the test description from `it("does something")` to `it.on
 
 #### Localhost
 
-Note, adjust the docker container name as needed (if for example you are using the sinopia_editor instance of mongo):
+`docker exec -it sinopia_api-mongo-1 mongo`
 
-`docker exec -it sinopia_api_mongo_1 mongo`
+Note that it may be easier and more productive to use the mongo docker container from sinopia_editor (since it may have more data to work with).  In this case, spin up the mongo containers from sinopia_editor and the connect to that mongo instance (and leave it running with the local sinopia_api dev instance for testing in your browser):
+
+```
+# cd into the sinopia_editor folder
+docker compose up -d mongo
+docker exec -it sinopia_editor-mongo-1 mongo
+```
 
 #### Dev/Stage/Prod
 

--- a/__tests__/endpoints/metrics.test.js
+++ b/__tests__/endpoints/metrics.test.js
@@ -1,0 +1,13 @@
+import request from "supertest"
+import app from "app.js"
+
+describe("GET /metrics/userCount", () => {
+  it("returns the total user count", async () => {
+    const res = await request(app)
+      .get("/metrics/userCount")
+      .set("Accept", "application/json")
+    expect(res.statusCode).toEqual(200)
+    expect(res.type).toEqual("application/json")
+    expect(res.body).toEqual({ count: 1 })
+  })
+})

--- a/__tests__/endpoints/metrics.test.js
+++ b/__tests__/endpoints/metrics.test.js
@@ -4,11 +4,19 @@ import app from "app.js"
 
 jest.mock("mongo.js")
 
+const mockResponse = jest.fn().mockResolvedValue(1)
 const response = { count: 1 }
+const templateOnlyQuery = {
+  types: "http://sinopia.io/vocabulary/ResourceTemplate",
+}
+const resourceOnlyQuery = {
+  types: {
+    $not: { $eq: "http://sinopia.io/vocabulary/ResourceTemplate" },
+  },
+}
 
 describe("GET /metrics/userCount", () => {
   it("returns the total user count", async () => {
-    const mockResponse = jest.fn().mockResolvedValue(response)
     const mockCollection = (collectionName) => {
       return {
         users: { count: mockResponse },
@@ -23,5 +31,61 @@ describe("GET /metrics/userCount", () => {
     expect(res.statusCode).toEqual(200)
     expect(res.type).toEqual("application/json")
     expect(res.body).toEqual(response)
+  })
+})
+
+describe("GET /metrics/resourceCount", () => {
+  it("returns the total resource count when user asks for 'all'", async () => {
+    const mockCollection = (collectionName) => {
+      return {
+        resources: { count: mockResponse },
+      }[collectionName]
+    }
+    const mockDb = { collection: mockCollection }
+    connect.mockImplementation(mockConnect(mockDb))
+
+    const res = await request(app)
+      .get("/metrics/resourceCount/all")
+      .set("Accept", "application/json")
+    expect(res.statusCode).toEqual(200)
+    expect(res.type).toEqual("application/json")
+    expect(res.body).toEqual(response)
+    expect(mockResponse).toHaveBeenCalledWith(null)
+  })
+
+  it("returns the just the resource templates resource count when user asks for 'template'", async () => {
+    const mockCollection = (collectionName) => {
+      return {
+        resources: { count: mockResponse },
+      }[collectionName]
+    }
+    const mockDb = { collection: mockCollection }
+    connect.mockImplementation(mockConnect(mockDb))
+
+    const res = await request(app)
+      .get("/metrics/resourceCount/template")
+      .set("Accept", "application/json")
+    expect(res.statusCode).toEqual(200)
+    expect(res.type).toEqual("application/json")
+    expect(res.body).toEqual(response)
+    expect(mockResponse).toHaveBeenCalledWith(templateOnlyQuery)
+  })
+
+  it("returns the just the resources count when user asks for 'resource'", async () => {
+    const mockCollection = (collectionName) => {
+      return {
+        resources: { count: mockResponse },
+      }[collectionName]
+    }
+    const mockDb = { collection: mockCollection }
+    connect.mockImplementation(mockConnect(mockDb))
+
+    const res = await request(app)
+      .get("/metrics/resourceCount/resource")
+      .set("Accept", "application/json")
+    expect(res.statusCode).toEqual(200)
+    expect(res.type).toEqual("application/json")
+    expect(res.body).toEqual(response)
+    expect(mockResponse).toHaveBeenCalledWith(resourceOnlyQuery)
   })
 })

--- a/__tests__/endpoints/metrics.test.js
+++ b/__tests__/endpoints/metrics.test.js
@@ -1,13 +1,27 @@
+import connect from "mongo.js"
 import request from "supertest"
 import app from "app.js"
 
+jest.mock("mongo.js")
+
+const response = { count: 1 }
+
 describe("GET /metrics/userCount", () => {
   it("returns the total user count", async () => {
+    const mockResponse = jest.fn().mockResolvedValue(response)
+    const mockCollection = (collectionName) => {
+      return {
+        users: { count: mockResponse },
+      }[collectionName]
+    }
+    const mockDb = { collection: mockCollection }
+    connect.mockImplementation(mockConnect(mockDb))
+
     const res = await request(app)
       .get("/metrics/userCount")
       .set("Accept", "application/json")
     expect(res.statusCode).toEqual(200)
     expect(res.type).toEqual("application/json")
-    expect(res.body).toEqual({ count: 1 })
+    expect(res.body).toEqual(response)
   })
 })

--- a/openapi.yml
+++ b/openapi.yml
@@ -27,6 +27,8 @@ tags:
     description: Healthcheck and monitoring
   - name: users
     description: Users
+  - name: metrics
+    description: Metrics for reporting
 paths:
   /:
     get:
@@ -40,6 +42,21 @@ paths:
             application/json:
               schema:
                 type: object
+  /metrics/userCount:
+    get:
+      summary: Get the total number of registered users
+      tags:
+        - metrics
+      responses:
+        "200":
+          description: The number of registered users
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
   /resource:
     get:
       summary: Returns a paged JSON result of all or filtered resources

--- a/openapi.yml
+++ b/openapi.yml
@@ -57,6 +57,32 @@ paths:
                 properties:
                   count:
                     type: integer
+  /metrics/resourceCount/{resourceType}:
+    get:
+      summary: Get the total number of resources
+      tags:
+        - metrics
+      responses:
+        "200":
+          description: The number of resources
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+      parameters:
+        - name: resourceType
+          in: path
+          description: The type of resource to count; "template" counts only resource template, "resource" counts only resources, "all" counts both
+          required: true
+          schema:
+            type: string
+            enum:
+              - template
+              - resource
+              - all
   /resource:
     get:
       summary: Returns a paged JSON result of all or filtered resources

--- a/openapi.yml
+++ b/openapi.yml
@@ -73,16 +73,8 @@ paths:
                   count:
                     type: integer
       parameters:
-        - name: resourceType
-          in: path
-          description: The type of resource to count; "template" counts only resource template, "resource" counts only resources, "all" counts both
-          required: true
-          schema:
-            type: string
-            enum:
-              - template
-              - resource
-              - all
+        - $ref: "#/components/parameters/resourceType"
+
   /resource:
     get:
       summary: Returns a paged JSON result of all or filtered resources
@@ -668,6 +660,18 @@ paths:
               required:
                 - payload
 components:
+  parameters:
+    resourceType:
+      in: path
+      name: resourceType
+      required: true
+      description: The available resource types to request for metrics
+      schema:
+        type: string
+        enum:
+          - template
+          - resource
+          - all
   schemas:
     History:
       description: History for a particular history type.

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ import jwtConfig from "./jwt.js"
 import resourcesRouter from "./endpoints/resources.js"
 import groupsRouter from "./endpoints/groups.js"
 import marcRouter from "./endpoints/marc.js"
+import metricsRouter from "./endpoints/metrics.js"
 import transferRouter from "./endpoints/transfer.js"
 import usersRouter from "./endpoints/users.js"
 import {
@@ -78,6 +79,7 @@ app.use("/marc", marcRouter)
 app.use("/groups", groupsRouter)
 app.use("/transfer", transferRouter)
 app.use("/user", usersRouter)
+app.use("/metrics", metricsRouter)
 
 // Error handlers
 app.use((err, req, res, next) => {

--- a/src/endpoints/metrics.js
+++ b/src/endpoints/metrics.js
@@ -6,10 +6,38 @@ const metricsRouter = express.Router()
 // Add the db to req
 metricsRouter.use(connect)
 
+/**
+ * Returns the mongo query to use for the specified resource type
+ * @param {string} resourceType  The resource type ("template", "resource" or "all")
+ * @returns {object} The query to send to mongo to filter by the requested type
+ */
+const getResourceQuery = (resourceType) => {
+  if (resourceType === "template") {
+    return { types: "http://sinopia.io/vocabulary/ResourceTemplate" }
+  }
+  if (resourceType === "resource") {
+    return {
+      types: {
+        $not: { $eq: "http://sinopia.io/vocabulary/ResourceTemplate" },
+      },
+    }
+  }
+  // This is reached by sending a value of "all" which is contrained by openapi
+  return null
+}
+
 metricsRouter.get("/userCount", (req, res, next) => {
   req.db
     .collection("users")
     .count()
+    .then((response) => res.send({ count: response }))
+    .catch(next)
+})
+
+metricsRouter.get("/resourceCount/:resourceType", (req, res, next) => {
+  req.db
+    .collection("resources")
+    .count(getResourceQuery(req.params.resourceType))
     .then((response) => res.send({ count: response }))
     .catch(next)
 })

--- a/src/endpoints/metrics.js
+++ b/src/endpoints/metrics.js
@@ -1,0 +1,17 @@
+import express from "express"
+import connect from "../mongo.js"
+
+const metricsRouter = express.Router()
+
+// Add the db to req
+metricsRouter.use(connect)
+
+metricsRouter.get("/userCount", (req, res, next) => {
+  req.db
+    .collection("users")
+    .count()
+    .then((response) => res.send({ count: response }))
+    .catch(next)
+})
+
+export default metricsRouter


### PR DESCRIPTION
## Why was this change made?

Fixes #226 - add a new metrics API endpoint that counts that total users and resources in the system (the "Quantity of users and resources" queries in #215)

Also update the README with some info on the frameworks used and some hints on how to develop with mongo and local the local API app running.

## How was this change tested?

Added new tests


## Which documentation and/or configurations were updated?




