### PR TITLE
usage by time period metric

### DIFF
--- a/__tests__/endpoints/metrics.test.js
+++ b/__tests__/endpoints/metrics.test.js
@@ -94,10 +94,12 @@ describe("GET /metrics/resourceCount", () => {
 })
 
 describe("GET /metrics/createdCount", () => {
+  const mockAggregateResponse = jest.fn().mockResolvedValue([{count: 1}])
+
   it("adds correct filters for date and resource type", async () => {
     const mockCollection = (collectionName) => {
       return {
-        resources: { aggregate: jest.fn().mockResolvedValue([response]) },
+        resources: { aggregate: mockAggregateResponse },
       }[collectionName]
     }
     const mockDb = { collection: mockCollection }
@@ -106,12 +108,9 @@ describe("GET /metrics/createdCount", () => {
     const res = await request(app)
       .get("/metrics/createdCount/all?startDate=2021-10-01&endDate=2021-11-01")
       .set("Accept", "application/json")
-    console.log(res)
     expect(res.statusCode).toEqual(200)
     expect(res.type).toEqual("application/json")
     expect(res.body).toEqual(response)
-    expect(mockResponse).toHaveBeenCalledWith(
-      expect.objectContaining({ $match: allResourceQuery })
-    )
+    expect(mockAggregateResponse.mock.calls[0][0][0]).toEqual({ $match: allResourceQuery })
   })
 })

--- a/openapi.yml
+++ b/openapi.yml
@@ -74,7 +74,40 @@ paths:
                     type: integer
       parameters:
         - $ref: "#/components/parameters/resourceType"
-
+  /metrics/createdCount/{resourceType}:
+    get:
+      summary: Get the total number of resources created in a specified time period, optionally filtered by group
+      tags:
+        - metrics
+      responses:
+        "200":
+          description: The number of resources created during a specified time period
+          content:
+            application/json:
+              schema:
+                type: object
+      parameters:
+        - $ref: "#/components/parameters/resourceType"
+        - name: startDate
+          in: query
+          schema:
+            type: string
+            format: date
+          required: true
+          description: The start date requested for the count (in ISO format, e.g. 2017-07-21)
+        - name: endDate
+          in: query
+          schema:
+            type: string
+            format: date
+          required: true
+          description: The end date requested for the count (in ISO format, e.g. 2017-07-21)
+        - name: group
+          in: query
+          schema:
+            type: string
+          required: false
+          description: The group to filter by (e.g. stanford)
   /resource:
     get:
       summary: Returns a paged JSON result of all or filtered resources

--- a/openapi.yml
+++ b/openapi.yml
@@ -53,10 +53,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
+                $ref: "#/components/schemas/MetricsCountResponse"
   /metrics/resourceCount/{resourceType}:
     get:
       summary: Get the total number of resources
@@ -68,10 +65,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
+                $ref: "#/components/schemas/MetricsCountResponse"
       parameters:
         - $ref: "#/components/parameters/resourceType"
   /metrics/createdCount/{resourceType}:
@@ -85,7 +79,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: "#/components/schemas/MetricsCountResponse"
       parameters:
         - $ref: "#/components/parameters/resourceType"
         - name: startDate
@@ -706,6 +700,13 @@ components:
           - resource
           - all
   schemas:
+    MetricsCountResponse:
+      description: Response from metrics endpoints that provide counts.
+      type: object
+      properties:
+        count:
+          description: The number of items matching the metric query.
+          type: integer
     History:
       description: History for a particular history type.
       type: array


### PR DESCRIPTION
## Why was this change made?

Fixes #230 - add api endpoints for various usage by time period (optionally filtered by group)


## How was this change tested?

Added new tests, localhost browser


## Which documentation and/or configurations were updated?




