### PR TITLE
add edited count metrics endpoint and tests

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -102,6 +102,40 @@ paths:
             type: string
           required: false
           description: The group to filter by (e.g. stanford)
+  /metrics/editedCount/{resourceType}:
+    get:
+      summary: Get the total number of resources edited in a specified time period, optionally filtered by group
+      tags:
+        - metrics
+      responses:
+        "200":
+          description: The number of resources edited during a specified time period
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricsCountResponse"
+      parameters:
+        - $ref: "#/components/parameters/resourceType"
+        - name: startDate
+          in: query
+          schema:
+            type: string
+            format: date
+          required: true
+          description: The start date requested for the count (in ISO format, e.g. 2017-07-21)
+        - name: endDate
+          in: query
+          schema:
+            type: string
+            format: date
+          required: true
+          description: The end date requested for the count (in ISO format, e.g. 2017-07-21)
+        - name: group
+          in: query
+          schema:
+            type: string
+          required: false
+          description: The group to filter by (e.g. stanford)
   /resource:
     get:
       summary: Returns a paged JSON result of all or filtered resources


### PR DESCRIPTION
## Why was this change made?

Fixes #237 - adds metric API endpoints for edited resources, matching the endpoint for "created" in #233 (i.e. one endpoint gives a total of resources that were created in the specified time period, this endpoint expands that count to include any resources that were edited in the specified time period), optionally filtered by group.

## How was this change tested?

Added new tests, localhost browser.

## Which documentation and/or configurations were updated?




