### PR TITLE
add template usage query metric and test

### DIFF
--- a/__tests__/endpoints/metrics.test.js
+++ b/__tests__/endpoints/metrics.test.js
@@ -264,3 +264,22 @@ describe("GET /metrics/editedCount", () => {
     expect(res.body).toEqual({ count: 0 })
   })
 })
+
+describe("GET /metrics/templateUsageCount", () => {
+  it("returns the total resources created from a given template id", async () => {
+    const mockCollection = (collectionName) => {
+      return {
+        resources: { count: mockResponse },
+      }[collectionName]
+    }
+    const mockDb = { collection: mockCollection }
+    connect.mockImplementation(mockConnect(mockDb))
+
+    const res = await request(app)
+      .get("/metrics/templateUsageCount?templateId=some%3Aid%3Ahere")
+      .set("Accept", "application/json")
+    expect(res.statusCode).toEqual(200)
+    expect(res.type).toEqual("application/json")
+    expect(res.body).toEqual(response)
+  })
+})

--- a/openapi.yml
+++ b/openapi.yml
@@ -102,6 +102,25 @@ paths:
         - $ref: "#/components/parameters/startDate"
         - $ref: "#/components/parameters/endDate"
         - $ref: "#/components/parameters/group"
+  /metrics/templateUsageCount:
+    get:
+      summary: Get the total number of resources created with the specified template Id
+      tags:
+        - metrics
+      responses:
+        "200":
+          description: The number of resources created with the given template
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricsCountResponse"
+      parameters:
+        - name: templateId
+          in: query
+          schema:
+            type: string
+          required: true
+          description: The ID of the template to count resources for
   /resource:
     get:
       summary: Returns a paged JSON result of all or filtered resources

--- a/src/endpoints/metrics.js
+++ b/src/endpoints/metrics.js
@@ -117,6 +117,14 @@ metricsRouter.get("/editedCount/:resourceType", (req, res, next) => {
     .catch(next)
 })
 
+metricsRouter.get("/templateUsageCount", (req, res, next) => {
+  req.db
+    .collection("resources")
+    .count({ templateId: req.query.templateId })
+    .then((response) => res.send({ count: response }))
+    .catch(next)
+})
+
 /**
  * Returns the response to the client for count aggregate mongo queries
  * Aggregate count queries return an array, and we are returning the count from this, so return the first element.


### PR DESCRIPTION
## Why was this change made?

Fixes #239 - create an API endpoint for the resources created by a given template metric

## How was this change tested?

Added new test



## Which documentation and/or configurations were updated?




