### PR TITLE
date ranges should be inclusive when querying mongo

### DIFF
--- a/__tests__/endpoints/metrics.test.js
+++ b/__tests__/endpoints/metrics.test.js
@@ -63,8 +63,8 @@ describe("GET /metrics/resourceUserCount", () => {
     )
     // The date filter
     expect(mockAggregateResponse.mock.calls[0][1].timestamp).toEqual({
-      $gt: new Date("2021-10-01"),
-      $lt: new Date("2021-11-01"),
+      $gte: new Date("2021-10-01"),
+      $lte: new Date("2021-11-01"),
     })
   })
 })
@@ -149,8 +149,8 @@ describe("GET /metrics/createdCount", () => {
     expect(mockAggregateResponse.mock.calls[0][0][3]).toEqual({
       $match: {
         "resourceMetadata.versions.0.timestamp": {
-          $gt: new Date("2021-10-01"),
-          $lt: new Date("2021-11-01"),
+          $gte: new Date("2021-10-01"),
+          $lte: new Date("2021-11-01"),
         },
       },
     })
@@ -183,8 +183,8 @@ describe("GET /metrics/createdCount", () => {
     expect(mockAggregateResponse.mock.calls[0][0][3]).toEqual({
       $match: {
         "resourceMetadata.versions.0.timestamp": {
-          $gt: new Date("2021-01-01"),
-          $lt: new Date("2021-12-31"),
+          $gte: new Date("2021-01-01"),
+          $lte: new Date("2021-12-31"),
         },
       },
     })
@@ -234,8 +234,8 @@ describe("GET /metrics/editedCount", () => {
     expect(mockAggregateResponse.mock.calls[0][0][3]).toEqual({
       $match: {
         "resourceMetadata.versions.timestamp": {
-          $gt: new Date("2021-10-01"),
-          $lt: new Date("2021-11-01"),
+          $gte: new Date("2021-10-01"),
+          $lte: new Date("2021-11-01"),
         },
       },
     })
@@ -268,8 +268,8 @@ describe("GET /metrics/editedCount", () => {
     expect(mockAggregateResponse.mock.calls[0][0][3]).toEqual({
       $match: {
         "resourceMetadata.versions.timestamp": {
-          $gt: new Date("2021-01-01"),
-          $lt: new Date("2021-12-31"),
+          $gte: new Date("2021-01-01"),
+          $lte: new Date("2021-12-31"),
         },
       },
     })

--- a/src/endpoints/metrics.js
+++ b/src/endpoints/metrics.js
@@ -40,8 +40,8 @@ const getResourceQuery = (resourceType) => {
  */
 const getDateQuery = (startDate, endDate) => {
   return {
-    $gt: new Date(startDate),
-    $lt: new Date(endDate),
+    $gte: new Date(startDate),
+    $lte: new Date(endDate),
   }
 }
 


### PR DESCRIPTION
## Why was this change made?

Fixes #244 - date range queries should be inclusive of the provided dates

## How was this change tested?

Updated the tests

## Which documentation and/or configurations were updated?




