### PR TITLE
Correctly handles S3 listing when empty.

### DIFF
--- a/__tests__/aws.marc.test.js
+++ b/__tests__/aws.marc.test.js
@@ -140,9 +140,8 @@ describe("hasMarc", () => {
 
   describe("finds no files", () => {
     it("resolves false", async () => {
-      mockS3Send.mockResolvedValue({
-        Contents: [],
-      })
+      // Contents key is omitted.
+      mockS3Send.mockResolvedValue({})
       expect(
         await hasMarc(
           "6852a770-2961-4836-a833-0b21a9b68041",

--- a/src/aws.js
+++ b/src/aws.js
@@ -68,11 +68,11 @@ export const hasMarc = async (resourceId, username, timestamp) => {
     Prefix: `marc/${username}/${resourceId}/${timestamp}`,
   }
   const listResp = await s3Client.send(new ListObjectsV2Command(params))
-  if (listResp.Contents.find((content) => content.Key.endsWith("error.txt"))) {
+  if (listResp.Contents?.find((content) => content.Key.endsWith("error.txt"))) {
     const errorTxt = await getError(resourceId, username, timestamp)
     throw new Error(errorTxt)
   } else if (
-    listResp.Contents.find((content) => content.Key.endsWith("record.mar"))
+    listResp.Contents?.find((content) => content.Key.endsWith("record.mar"))
   ) {
     return true
   }


### PR DESCRIPTION
## Why was this change made?
Per @michelleif generating MARC wasn't working.


## How was this change tested?
Development


## Which documentation and/or configurations were updated?




