### PR TITLE
Updates node.js to 22.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  node: circleci/node@5.0.2
+  node: circleci/node@7.0.0
   docker: circleci/docker@2.5.0
   aws-cli: circleci/aws-cli@3.1.0
   gh: circleci/github-cli@2.2.0
@@ -8,7 +8,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: 'cimg/node:20.11'
+      - image: 'cimg/node:22.13.0'
 references:
   publish_params: &publish_params
     docker-password: DOCKER_PASS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:16.8
+FROM cimg/node:22.13.0
 
 WORKDIR /home/circleci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "supertest": "^6.1.6"
       },
       "engines": {
-        "node": ">= 16.8.0"
+        "node": ">= 22.13.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/LD4P/sinopia_api",
   "repository": "github:LD4P/sinopia_api",
   "engines": {
-    "node": ">= 16.8.0"
+    "node": ">= 22.13.0"
   },
   "scripts": {
     "dev-start": "nodemon src/server.js",


### PR DESCRIPTION
## Why was this change made?
AWS package no longer supports node 16.x


## How was this change tested?
unit tests


## Which documentation and/or configurations were updated?
`package.json` and `package-lock.json`



